### PR TITLE
build: change versioning rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .cxx
 local.properties
 /Gemfile.lock
+/VERSION

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,14 +27,14 @@ android {
 
         val versionNamePatchVer = patch * 5
         val abiFilterList = property("abiFilters").toString().split(';')
-        val versionCodePatchVer = versionNamePatchVer +
-                when (abiFilterList.takeIf { it.size == 1 }?.first()) {
-                    "armeabi-v7a" -> 1
-                    "arm64-v8a" -> 2
-                    "x86" -> 3
-                    "x86_64" -> 4
-                    else -> 0
-                }
+        val singleAbiNum = when (abiFilterList.takeIf { it.size == 1 }?.first()) {
+            "armeabi-v7a" -> 1
+            "arm64-v8a" -> 2
+            "x86" -> 3
+            "x86_64" -> 4
+            else -> 0
+        }
+        val versionCodePatchVer = versionNamePatchVer + singleAbiNum
 
         versionCode = major * 10000 + minor * 100 + versionCodePatchVer
         versionName = "$major.$minor.$versionNamePatchVer"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,17 @@ android {
         ndk {
             abiFilters += abiFilterList
         }
+
+        tasks.preBuild {
+            doLast {
+                val androidConfig = android.defaultConfig
+                val text = """
+                versionCode=${androidConfig.versionCode}
+                versionName=${androidConfig.versionName}
+                """.trimIndent()
+                file("$rootDir/VERSION").writeText(text)
+            }
+        }
     }
 
     packagingOptions {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,14 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
 }
 
+// This versioning probably follows semver.org
+val major = 0
+val minor = 1
+// Max:19
+// Patch always calculated at five times in versionName and also adds abiFilter numberings in versionCode.
+// Please see actualPatchVer.
+val patch = 0
+
 android {
     compileSdk = 33
 
@@ -17,17 +25,24 @@ android {
         minSdk = 24
         targetSdk = 33
 
-        val major = 0
-        val minor = 1
-        val patch = 0
-        versionCode = (major * 10000 + minor * 100 + patch)
-        versionName = "$major.$minor.$patch"
+        val versionNamePatchVer = patch * 5
+        val abiFilterList = property("abiFilters").toString().split(';')
+        val versionCodePatchVer = versionNamePatchVer +
+                when (abiFilterList.takeIf { it.size == 1 }?.first()) {
+                    "armeabi-v7a" -> 1
+                    "arm64-v8a" -> 2
+                    "x86" -> 3
+                    "x86_64" -> 4
+                    else -> 0
+                }
+
+        versionCode = major * 10000 + minor * 100 + versionCodePatchVer
+        versionName = "$major.$minor.$versionNamePatchVer"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {
-            val abiFilters: String by project
-            this.abiFilters += abiFilters.split(';')
+            abiFilters += abiFilterList
         }
     }
 


### PR DESCRIPTION
# Type

Cross out these that do not apply.  
当てはまらないものを消してください

- Other(その他)

# Description

Describe changes 
変更内容の説明

I changed patch versioning rule. It always calculated at five times.
I also added version file output task.

# Related Issues

Nothing

# Before finish

Please check all in lists before say ready to merge.  
作業後に全てにチェックを入れてください

- [x] I read the [Contributing guide](https://github.com/turtton/YtAlarm/blob/HEAD/.github/CONTRIBUTING.md).  
  [コントリビューションガイド](https://github.com/turtton/YtAlarm/blob/HEAD/docs/contributing/CONTRIBUTING_ja.md)を熟読しました
- [x] Run Gradle tasks `formatKotlin` and `check` and make sure no error message is displayed.  
  GradleTaskの`formatKotlin`と`check`を実行し、エラーが無いことを確認しました
- [x] Removed unnecessary commented out code and debug print code.  
  不要なコメントアウトとデバッグ用のコードを削除しました

