### PR TITLE
refactor(test): migrate usecase tests from Mockito to reusable Fake objects

### DIFF
--- a/kernel/build.gradle.kts
+++ b/kernel/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    `java-test-fixtures`
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.detekt)
@@ -22,6 +23,9 @@ dependencies {
     implementation(libs.bundles.kotlinx.serialization)
     implementation(libs.kotlinx.datetime)
     implementation(libs.bundles.arrow)
+
+    testFixturesImplementation(libs.kotlinx.coroutines.core)
+    testFixturesImplementation(libs.bundles.arrow)
 
     testImplementation(libs.bundles.kotest)
 }

--- a/kernel/src/test/kotlin/net/turtton/ytalarm/kernel/entity/AlarmSchedulingTest.kt
+++ b/kernel/src/test/kotlin/net/turtton/ytalarm/kernel/entity/AlarmSchedulingTest.kt
@@ -262,5 +262,336 @@ class AlarmSchedulingTest :
                 val nowAt1230 = makeNow(hour = 12, minute = 30)
                 nowAt1230.isPrevOrSameTime(12, 50, tz) shouldBe false
             }
+            test("midnight boundary: now=00:00, alarm=00:00") {
+                val midnight = makeNow(hour = 0, minute = 0)
+                midnight.isPrevOrSameTime(0, 0, tz) shouldBe true
+            }
+            test("midnight boundary: now=00:00, alarm=00:01") {
+                val midnight = makeNow(hour = 0, minute = 0)
+                midnight.isPrevOrSameTime(0, 1, tz) shouldBe false
+            }
+            test("end of day: now=23:59, alarm=23:59") {
+                val endOfDay = makeNow(hour = 23, minute = 59)
+                endOfDay.isPrevOrSameTime(23, 59, tz) shouldBe true
+            }
+            test("end of day: now=23:59, alarm=0:00") {
+                val endOfDay = makeNow(hour = 23, minute = 59)
+                endOfDay.isPrevOrSameTime(0, 0, tz) shouldBe true
+            }
+        }
+
+        context("toNextFireTime — midnight boundary (00:00)") {
+            test("Once: alarm at 00:00, now=23:59 → next day") {
+                val now2359 = makeNow(hour = 23, minute = 59)
+                val alarm = Alarm(hour = 0, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(now2359, tz)
+                val expected = makeNow(dayOfMonth = 2, hour = 0, minute = 0)
+                target shouldBe expected
+            }
+
+            test("Once: alarm at 00:00, now=00:00 → fires next day") {
+                val nowMidnight = makeNow(hour = 0, minute = 0)
+                val alarm = Alarm(hour = 0, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(nowMidnight, tz)
+                val expected = makeNow(dayOfMonth = 2, hour = 0, minute = 0)
+                target shouldBe expected
+            }
+
+            test("Everyday: alarm at 23:59, now=23:58 → fires same day") {
+                val now2358 = makeNow(hour = 23, minute = 58)
+                val alarm = Alarm(hour = 23, minute = 59, repeatType = Alarm.RepeatType.Everyday)
+                val target = alarm.toNextFireTime(now2358, tz)
+                val expected = makeNow(hour = 23, minute = 59)
+                target shouldBe expected
+            }
+
+            test("Everyday: alarm at 23:59, now=23:59 → fires next day") {
+                val now2359 = makeNow(hour = 23, minute = 59)
+                val alarm = Alarm(hour = 23, minute = 59, repeatType = Alarm.RepeatType.Everyday)
+                val target = alarm.toNextFireTime(now2359, tz)
+                val expected = makeNow(dayOfMonth = 2, hour = 23, minute = 59)
+                target shouldBe expected
+            }
+        }
+
+        context("toNextFireTime — month-end crossing") {
+            test("Once: July 31st, time passed → August 1st") {
+                val july31 = makeNow(dayOfMonth = 31, hour = 12, minute = 0)
+                val alarm = Alarm(hour = 11, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(july31, tz)
+                val expected = LocalDateTime(2022, 8, 1, 11, 0, 0).toInstant(tz)
+                target shouldBe expected
+            }
+
+            test("Everyday: month with 30 days — June 30th next day → July 1st") {
+                val june30 = LocalDateTime(2022, 6, 30, 18, 0, 0).toInstant(tz)
+                val alarm = Alarm(hour = 8, minute = 0, repeatType = Alarm.RepeatType.Everyday)
+                val target = alarm.toNextFireTime(june30, tz)
+                val expected = LocalDateTime(2022, 7, 1, 8, 0, 0).toInstant(tz)
+                target shouldBe expected
+            }
+        }
+
+        context("toNextFireTime — year-end crossing") {
+            test("Once: December 31st next day → January 1st next year") {
+                val dec31 = LocalDateTime(2022, 12, 31, 20, 0, 0).toInstant(tz)
+                val alarm = Alarm(hour = 6, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(dec31, tz)
+                val expected = LocalDateTime(2023, 1, 1, 6, 0, 0).toInstant(tz)
+                target shouldBe expected
+            }
+        }
+
+        context("toNextFireTime — leap year") {
+            test("Once: Feb 28 in leap year → Feb 29") {
+                val feb28 = LocalDateTime(2024, 2, 28, 20, 0, 0).toInstant(tz)
+                val alarm = Alarm(hour = 7, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(feb28, tz)
+                val expected = LocalDateTime(2024, 2, 29, 7, 0, 0).toInstant(tz)
+                target shouldBe expected
+            }
+
+            test("Once: Feb 28 in non-leap year → March 1") {
+                val feb28 = LocalDateTime(2023, 2, 28, 20, 0, 0).toInstant(tz)
+                val alarm = Alarm(hour = 7, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(feb28, tz)
+                val expected = LocalDateTime(2023, 3, 1, 7, 0, 0).toInstant(tz)
+                target shouldBe expected
+            }
+
+            test("Once: Feb 29 in leap year → March 1") {
+                val feb29 = LocalDateTime(2024, 2, 29, 20, 0, 0).toInstant(tz)
+                val alarm = Alarm(hour = 7, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(feb29, tz)
+                val expected = LocalDateTime(2024, 3, 1, 7, 0, 0).toInstant(tz)
+                target shouldBe expected
+            }
+
+            test("Date: Feb 29 in leap year — exact date used") {
+                val alarm = Alarm(
+                    hour = 8,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Date(LocalDate(2024, 2, 29))
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = LocalDateTime(2024, 2, 29, 8, 0, 0).toInstant(tz)
+                target shouldBe expected
+            }
+        }
+
+        context("toNextFireTime — RepeatType.Date edge cases") {
+            test("Date: past date returns past instant") {
+                val pastDate = LocalDate(2020, 1, 1)
+                val alarm = Alarm(
+                    hour = 9,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Date(pastDate)
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = LocalDateTime(2020, 1, 1, 9, 0, 0).toInstant(tz)
+                target shouldBe expected
+                (target < now) shouldBe true
+            }
+
+            test("Date: today's date with future time") {
+                val todayDate = LocalDate(2022, 7, 1)
+                val alarm = Alarm(
+                    hour = 15,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Date(todayDate)
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = makeNow(hour = 15, minute = 0)
+                target shouldBe expected
+            }
+
+            test("Date: today's date with past time still returns today") {
+                val todayDate = LocalDate(2022, 7, 1)
+                val alarm = Alarm(
+                    hour = 8,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Date(todayDate)
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                // Date type does NOT auto-advance to next day
+                val expected = makeNow(hour = 8, minute = 0)
+                target shouldBe expected
+            }
+        }
+
+        context("toNextFireTime — RepeatType.Days edge cases") {
+            test("all 7 days, time in future → fires same day") {
+                val allDays = DayOfWeek.entries.toList()
+                val alarm = Alarm(
+                    hour = 18,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Days(allDays)
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = makeNow(hour = 18, minute = 0)
+                target shouldBe expected
+            }
+
+            test("all 7 days, time passed → fires next day") {
+                val allDays = DayOfWeek.entries.toList()
+                val alarm = Alarm(
+                    hour = 8,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Days(allDays)
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = makeNow(dayOfMonth = 2, hour = 8, minute = 0)
+                target shouldBe expected
+            }
+
+            test("two days (Mon, Thu), now is Fri past time → skips to Mon") {
+                val alarm = Alarm(
+                    hour = 8,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Days(
+                        listOf(DayOfWeek.MONDAY, DayOfWeek.THURSDAY)
+                    )
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = makeNow(dayOfMonth = 4, hour = 8, minute = 0)
+                target shouldBe expected
+            }
+
+            test("two days (Fri, Sun), now is Fri time passed → fires Sun") {
+                val alarm = Alarm(
+                    hour = 8,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Days(
+                        listOf(DayOfWeek.FRIDAY, DayOfWeek.SUNDAY)
+                    )
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = makeNow(dayOfMonth = 3, hour = 8, minute = 0)
+                target shouldBe expected
+            }
+
+            test("Saturday only, now is Friday → fires next day (Saturday)") {
+                val alarm = Alarm(
+                    hour = 6,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Days(listOf(DayOfWeek.SATURDAY))
+                )
+                val target = alarm.toNextFireTime(now, tz)
+                val expected = makeNow(dayOfMonth = 2, hour = 6, minute = 0)
+                target shouldBe expected
+            }
+        }
+
+        context("pickNearestTime — additional cases") {
+            test("single alarm in list") {
+                val alarm = Alarm(hour = 15, minute = 0)
+                val result = listOf(alarm).pickNearestTime(now, tz)
+                result?.first shouldBe alarm
+                result?.second shouldBe makeNow(hour = 15, minute = 0)
+            }
+
+            test("mixed RepeatTypes: nearest is selected correctly") {
+                val onceAlarm = Alarm(hour = 14, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val everydayAlarm = Alarm(
+                    hour = 13,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Everyday
+                )
+                val daysAlarm = Alarm(
+                    hour = 15,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Days(listOf(DayOfWeek.FRIDAY))
+                )
+                // now is Fri 12:00
+                // Once 14:00 today, Everyday 13:00 today, Days(Fri) 15:00 today
+                // nearest = Everyday 13:00
+                val result = listOf(onceAlarm, everydayAlarm, daysAlarm)
+                    .pickNearestTime(now, tz)
+                result?.first shouldBe everydayAlarm
+            }
+
+            test("all alarms have Date in past: returns earliest past alarm") {
+                val alarm1 = Alarm(
+                    hour = 9,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Date(LocalDate(2021, 6, 1))
+                )
+                val alarm2 = Alarm(
+                    hour = 9,
+                    minute = 0,
+                    repeatType = Alarm.RepeatType.Date(LocalDate(2022, 1, 1))
+                )
+                val result = listOf(alarm1, alarm2).pickNearestTime(now, tz)
+                result?.first shouldBe alarm1
+            }
+        }
+
+        context("getNearestDayOfWeekOrNull — additional cases") {
+            test("empty list returns null") {
+                emptyList<DayOfWeek>().getNearestDayOfWeekOrNull(DayOfWeek.MONDAY) shouldBe null
+            }
+
+            test("single day, same as from") {
+                val days = listOf(DayOfWeek.WEDNESDAY)
+                days.getNearestDayOfWeekOrNull(DayOfWeek.WEDNESDAY) shouldBe DayOfWeek.WEDNESDAY
+            }
+
+            test("single day, before from → wraps to next week") {
+                val days = listOf(DayOfWeek.MONDAY)
+                days.getNearestDayOfWeekOrNull(DayOfWeek.FRIDAY) shouldBe DayOfWeek.MONDAY
+            }
+
+            test("all 7 days → returns from itself") {
+                val allDays = DayOfWeek.entries.toList()
+                allDays.getNearestDayOfWeekOrNull(DayOfWeek.THURSDAY) shouldBe DayOfWeek.THURSDAY
+            }
+
+            test("from=SUNDAY, list has MON and WED → wraps to MONDAY") {
+                val days = listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY)
+                // SUNDAY iso=7, no days >= 7 in list → wraps → min = MONDAY
+                days.getNearestDayOfWeekOrNull(DayOfWeek.SUNDAY) shouldBe DayOfWeek.MONDAY
+            }
+
+            test("from=MONDAY, list has SUN only → returns SUN (wrap)") {
+                val days = listOf(DayOfWeek.SUNDAY)
+                // SUNDAY iso=7 >= MONDAY iso=1 → same week, returns SUNDAY
+                days.getNearestDayOfWeekOrNull(DayOfWeek.MONDAY) shouldBe DayOfWeek.SUNDAY
+            }
+        }
+
+        context("isSameDate — timezone boundary") {
+            test("same instant, different timezone can yield different dates") {
+                // 2022-07-01 23:30 UTC = 2022-07-02 08:30 JST
+                val instant = LocalDateTime(2022, 7, 1, 23, 30, 0).toInstant(tz)
+                val jst = TimeZone.of("Asia/Tokyo")
+                // In UTC it's July 1, in JST it's July 2
+                val july1Noon = makeNow() // 2022-07-01 12:00 UTC
+                instant.isSameDate(july1Noon, tz) shouldBe true
+                instant.isSameDate(july1Noon, jst) shouldBe false
+            }
+        }
+
+        context("toNextFireTime — non-UTC timezone") {
+            test("alarm in JST respects timezone offset") {
+                val jst = TimeZone.of("Asia/Tokyo") // UTC+9
+                // 2022-07-01 21:00 JST = 2022-07-01 12:00 UTC
+                val nowJst = LocalDateTime(2022, 7, 1, 21, 0, 0).toInstant(jst)
+                val alarm = Alarm(hour = 22, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(nowJst, jst)
+                // 22:00 JST same day
+                val expected = LocalDateTime(2022, 7, 1, 22, 0, 0).toInstant(jst)
+                target shouldBe expected
+            }
+
+            test("alarm in JST crosses day differently than UTC") {
+                val jst = TimeZone.of("Asia/Tokyo")
+                // 2022-07-01 23:30 JST
+                val nowJst = LocalDateTime(2022, 7, 1, 23, 30, 0).toInstant(jst)
+                val alarm = Alarm(hour = 6, minute = 0, repeatType = Alarm.RepeatType.Once)
+                val target = alarm.toNextFireTime(nowJst, jst)
+                // 06:00 < 23:30 → next day in JST = July 2 06:00 JST
+                val expected = LocalDateTime(2022, 7, 2, 6, 0, 0).toInstant(jst)
+                target shouldBe expected
+            }
         }
     })

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeAlarmRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeAlarmRepository.kt
@@ -6,16 +6,19 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import net.turtton.ytalarm.kernel.entity.Alarm
 import net.turtton.ytalarm.kernel.repository.AlarmRepository
+import java.util.concurrent.atomic.AtomicLong
 
 class FakeAlarmRepository : AlarmRepository<Unit> {
     private val store = MutableStateFlow<List<Alarm>>(emptyList())
-    private var nextId = 1L
+    private val nextId = AtomicLong(1L)
 
     val currentData: List<Alarm> get() = store.value
+    val updateHistory: MutableList<Alarm> = mutableListOf()
 
-    fun seed(vararg alarms: Alarm) {
+    fun resetWith(vararg alarms: Alarm) {
         store.value = alarms.toList()
-        nextId = (alarms.maxOfOrNull { it.id } ?: 0L) + 1
+        nextId.set((alarms.maxOfOrNull { it.id } ?: 0L) + 1)
+        updateHistory.clear()
     }
 
     override fun getAll(executor: Unit): Flow<List<Alarm>> = store
@@ -29,13 +32,14 @@ class FakeAlarmRepository : AlarmRepository<Unit> {
         store.value.filter { it.repeatType == repeatType }
 
     override suspend fun insert(executor: Unit, alarm: Alarm): Long {
-        val id = nextId++
+        val id = nextId.getAndIncrement()
         val stored = alarm.copy(id = id)
         store.update { it + stored }
         return id
     }
 
     override suspend fun update(executor: Unit, alarm: Alarm) {
+        updateHistory.add(alarm)
         store.update { list -> list.map { if (it.id == alarm.id) alarm else it } }
     }
 

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeAlarmRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeAlarmRepository.kt
@@ -1,0 +1,45 @@
+package net.turtton.ytalarm.kernel.fake
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import net.turtton.ytalarm.kernel.entity.Alarm
+import net.turtton.ytalarm.kernel.repository.AlarmRepository
+
+class FakeAlarmRepository : AlarmRepository<Unit> {
+    private val store = MutableStateFlow<List<Alarm>>(emptyList())
+    private var nextId = 1L
+
+    val currentData: List<Alarm> get() = store.value
+
+    fun seed(vararg alarms: Alarm) {
+        store.value = alarms.toList()
+        nextId = (alarms.maxOfOrNull { it.id } ?: 0L) + 1
+    }
+
+    override fun getAll(executor: Unit): Flow<List<Alarm>> = store
+
+    override suspend fun getAllSync(executor: Unit): List<Alarm> = store.value
+
+    override suspend fun getFromId(executor: Unit, id: Long): Alarm? =
+        store.value.find { it.id == id }
+
+    override suspend fun getMatched(executor: Unit, repeatType: Alarm.RepeatType): List<Alarm> =
+        store.value.filter { it.repeatType == repeatType }
+
+    override suspend fun insert(executor: Unit, alarm: Alarm): Long {
+        val id = nextId++
+        val stored = alarm.copy(id = id)
+        store.update { it + stored }
+        return id
+    }
+
+    override suspend fun update(executor: Unit, alarm: Alarm) {
+        store.update { list -> list.map { if (it.id == alarm.id) alarm else it } }
+    }
+
+    override suspend fun delete(executor: Unit, alarm: Alarm) {
+        store.update { list -> list.filter { it.id != alarm.id } }
+    }
+}

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeAlarmSchedulerPort.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeAlarmSchedulerPort.kt
@@ -1,0 +1,22 @@
+package net.turtton.ytalarm.kernel.fake
+
+import arrow.core.Either
+import arrow.core.right
+import net.turtton.ytalarm.kernel.entity.Alarm
+import net.turtton.ytalarm.kernel.port.AlarmScheduleError
+import net.turtton.ytalarm.kernel.port.AlarmSchedulerPort
+
+class FakeAlarmSchedulerPort : AlarmSchedulerPort {
+    var scheduleResult: Either<AlarmScheduleError, Unit> = Unit.right()
+    val scheduledCalls: MutableList<List<Alarm>> = mutableListOf()
+    var cancelCount = 0
+
+    override suspend fun scheduleNextAlarm(alarms: List<Alarm>): Either<AlarmScheduleError, Unit> {
+        scheduledCalls.add(alarms)
+        return scheduleResult
+    }
+
+    override fun cancelAlarm() {
+        cancelCount++
+    }
+}

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeFileStoragePort.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeFileStoragePort.kt
@@ -1,0 +1,26 @@
+package net.turtton.ytalarm.kernel.fake
+
+import net.turtton.ytalarm.kernel.port.FileStoragePort
+import java.io.File
+
+class FakeFileStoragePort(
+    private val downloadDir: File = File(System.getProperty("java.io.tmpdir"), "fake-downloads")
+) : FileStoragePort {
+    val existingFiles: MutableSet<String> = mutableSetOf()
+    var totalSize: Long = 0L
+    var deleteCount = 0
+
+    override fun getDownloadDir(): File = downloadDir
+
+    override fun deleteAllDownloads(): Long {
+        deleteCount++
+        val deleted = existingFiles.size.toLong()
+        existingFiles.clear()
+        totalSize = 0L
+        return deleted
+    }
+
+    override fun getTotalDownloadSize(): Long = totalSize
+
+    override fun fileExists(relativePath: String): Boolean = relativePath in existingFiles
+}

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakePlaylistRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakePlaylistRepository.kt
@@ -1,0 +1,57 @@
+package net.turtton.ytalarm.kernel.fake
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import net.turtton.ytalarm.kernel.entity.Playlist
+import net.turtton.ytalarm.kernel.repository.PlaylistRepository
+
+class FakePlaylistRepository : PlaylistRepository<Unit> {
+    private val store = MutableStateFlow<List<Playlist>>(emptyList())
+    private var nextId = 1L
+
+    val currentData: List<Playlist> get() = store.value
+
+    fun seed(vararg playlists: Playlist) {
+        store.value = playlists.toList()
+        nextId = (playlists.maxOfOrNull { it.id } ?: 0L) + 1
+    }
+
+    override fun getAll(executor: Unit): Flow<List<Playlist>> = store
+
+    override fun getFromId(executor: Unit, id: Long): Flow<Playlist?> =
+        store.map { list -> list.find { it.id == id } }
+
+    override suspend fun getAllSync(executor: Unit): List<Playlist> = store.value
+
+    override suspend fun getFromIdSync(executor: Unit, id: Long): Playlist? =
+        store.value.find { it.id == id }
+
+    override suspend fun getFromIdsSync(executor: Unit, ids: List<Long>): List<Playlist> =
+        store.value.filter { it.id in ids }
+
+    override suspend fun update(executor: Unit, playlist: Playlist) {
+        store.update { list -> list.map { if (it.id == playlist.id) playlist else it } }
+    }
+
+    override suspend fun updateAll(executor: Unit, playlists: List<Playlist>) {
+        val updateMap = playlists.associateBy { it.id }
+        store.update { list -> list.map { updateMap[it.id] ?: it } }
+    }
+
+    override suspend fun insert(executor: Unit, playlist: Playlist): Long {
+        val id = nextId++
+        store.update { it + playlist.copy(id = id) }
+        return id
+    }
+
+    override suspend fun delete(executor: Unit, playlist: Playlist) {
+        store.update { list -> list.filter { it.id != playlist.id } }
+    }
+
+    override suspend fun deleteAll(executor: Unit, playlists: List<Playlist>) {
+        val deleteIds = playlists.map { it.id }.toSet()
+        store.update { list -> list.filter { it.id !in deleteIds } }
+    }
+}

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakePlaylistRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakePlaylistRepository.kt
@@ -6,16 +6,19 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import net.turtton.ytalarm.kernel.entity.Playlist
 import net.turtton.ytalarm.kernel.repository.PlaylistRepository
+import java.util.concurrent.atomic.AtomicLong
 
 class FakePlaylistRepository : PlaylistRepository<Unit> {
     private val store = MutableStateFlow<List<Playlist>>(emptyList())
-    private var nextId = 1L
+    private val nextId = AtomicLong(1L)
 
     val currentData: List<Playlist> get() = store.value
+    val updateHistory: MutableList<Playlist> = mutableListOf()
 
-    fun seed(vararg playlists: Playlist) {
+    fun resetWith(vararg playlists: Playlist) {
         store.value = playlists.toList()
-        nextId = (playlists.maxOfOrNull { it.id } ?: 0L) + 1
+        nextId.set((playlists.maxOfOrNull { it.id } ?: 0L) + 1)
+        updateHistory.clear()
     }
 
     override fun getAll(executor: Unit): Flow<List<Playlist>> = store
@@ -32,16 +35,20 @@ class FakePlaylistRepository : PlaylistRepository<Unit> {
         store.value.filter { it.id in ids }
 
     override suspend fun update(executor: Unit, playlist: Playlist) {
+        updateHistory.add(playlist)
         store.update { list -> list.map { if (it.id == playlist.id) playlist else it } }
     }
 
     override suspend fun updateAll(executor: Unit, playlists: List<Playlist>) {
-        val updateMap = playlists.associateBy { it.id }
-        store.update { list -> list.map { updateMap[it.id] ?: it } }
+        updateHistory.addAll(playlists)
+        store.update { list ->
+            val updateMap = playlists.associateBy { it.id }
+            list.map { updateMap[it.id] ?: it }
+        }
     }
 
     override suspend fun insert(executor: Unit, playlist: Playlist): Long {
-        val id = nextId++
+        val id = nextId.getAndIncrement()
         store.update { it + playlist.copy(id = id) }
         return id
     }

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoDownloadRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoDownloadRepository.kt
@@ -9,7 +9,6 @@ import net.turtton.ytalarm.kernel.repository.VideoDownloadRepository
 class FakeVideoDownloadRepository : VideoDownloadRepository<Unit> {
     var downloadResponses: MutableMap<String, Either<DownloadError, DownloadResult>> =
         mutableMapOf()
-    val downloadedUrls: MutableList<String> = mutableListOf()
     val downloadRequests: MutableList<DownloadRequest> = mutableListOf()
 
     data class DownloadRequest(
@@ -25,7 +24,6 @@ class FakeVideoDownloadRepository : VideoDownloadRepository<Unit> {
         formatSelector: String,
         onProgress: (Float) -> Unit
     ): Either<DownloadError, DownloadResult> {
-        downloadedUrls.add(videoUrl)
         downloadRequests.add(DownloadRequest(videoUrl, outputPath, formatSelector))
         onProgress(1.0f)
         return downloadResponses[videoUrl]

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoDownloadRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoDownloadRepository.kt
@@ -1,0 +1,34 @@
+package net.turtton.ytalarm.kernel.fake
+
+import arrow.core.Either
+import arrow.core.left
+import net.turtton.ytalarm.kernel.error.DownloadError
+import net.turtton.ytalarm.kernel.error.DownloadResult
+import net.turtton.ytalarm.kernel.repository.VideoDownloadRepository
+
+class FakeVideoDownloadRepository : VideoDownloadRepository<Unit> {
+    var downloadResponses: MutableMap<String, Either<DownloadError, DownloadResult>> =
+        mutableMapOf()
+    val downloadedUrls: MutableList<String> = mutableListOf()
+    val downloadRequests: MutableList<DownloadRequest> = mutableListOf()
+
+    data class DownloadRequest(
+        val videoUrl: String,
+        val outputPath: String,
+        val formatSelector: String
+    )
+
+    override suspend fun downloadVideo(
+        executor: Unit,
+        videoUrl: String,
+        outputPath: String,
+        formatSelector: String,
+        onProgress: (Float) -> Unit
+    ): Either<DownloadError, DownloadResult> {
+        downloadedUrls.add(videoUrl)
+        downloadRequests.add(DownloadRequest(videoUrl, outputPath, formatSelector))
+        onProgress(1.0f)
+        return downloadResponses[videoUrl]
+            ?: DownloadError.FormatNotAvailable(videoUrl, formatSelector).left()
+    }
+}

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoInfoRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoInfoRepository.kt
@@ -1,0 +1,36 @@
+package net.turtton.ytalarm.kernel.fake
+
+import arrow.core.Either
+import arrow.core.left
+import net.turtton.ytalarm.kernel.dto.VideoInformation
+import net.turtton.ytalarm.kernel.error.StreamError
+import net.turtton.ytalarm.kernel.error.VideoInfoError
+import net.turtton.ytalarm.kernel.repository.VideoInfoRepository
+
+class FakeVideoInfoRepository : VideoInfoRepository<Unit> {
+    var videoInfoResponses: MutableMap<String, Either<VideoInfoError, VideoInformation>> =
+        mutableMapOf()
+    var playlistInfoResponses:
+        MutableMap<String, Either<VideoInfoError, List<VideoInformation>>> =
+        mutableMapOf()
+    var streamUrlResponses: MutableMap<String, Either<StreamError, String>> = mutableMapOf()
+
+    override suspend fun fetchVideoInfo(
+        executor: Unit,
+        url: String
+    ): Either<VideoInfoError, VideoInformation> = videoInfoResponses[url]
+        ?: VideoInfoError.UnsupportedUrl(url).left()
+
+    override suspend fun fetchPlaylistInfo(
+        executor: Unit,
+        url: String
+    ): Either<VideoInfoError, List<VideoInformation>> = playlistInfoResponses[url]
+        ?: VideoInfoError.UnsupportedUrl(url).left()
+
+    override suspend fun getStreamUrl(
+        executor: Unit,
+        videoUrl: String,
+        formatSelector: String
+    ): Either<StreamError, String> = streamUrlResponses[videoUrl]
+        ?: StreamError.FormatNotAvailable(videoUrl, formatSelector).left()
+}

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoRepository.kt
@@ -6,17 +6,18 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.kernel.repository.VideoRepository
+import java.util.concurrent.atomic.AtomicLong
 
 class FakeVideoRepository : VideoRepository<Unit> {
     private val store = MutableStateFlow<List<Video>>(emptyList())
-    private var nextId = 1L
+    private val nextId = AtomicLong(1L)
 
     val currentData: List<Video> get() = store.value
     val updateHistory: MutableList<Video> = mutableListOf()
 
-    fun seed(vararg videos: Video) {
+    fun resetWith(vararg videos: Video) {
         store.value = videos.toList()
-        nextId = (videos.maxOfOrNull { it.id } ?: 0L) + 1
+        nextId.set((videos.maxOfOrNull { it.id } ?: 0L) + 1)
         updateHistory.clear()
     }
 
@@ -52,13 +53,13 @@ class FakeVideoRepository : VideoRepository<Unit> {
     }
 
     override suspend fun insert(executor: Unit, video: Video): Long {
-        val id = nextId++
+        val id = nextId.getAndIncrement()
         store.update { it + video.copy(id = id) }
         return id
     }
 
     override suspend fun insertAll(executor: Unit, videos: List<Video>): List<Long> {
-        val ids = videos.map { nextId++ }
+        val ids = videos.map { nextId.getAndIncrement() }
         val stored = videos.zip(ids) { v, id -> v.copy(id = id) }
         store.update { it + stored }
         return ids

--- a/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoRepository.kt
+++ b/kernel/src/testFixtures/kotlin/net/turtton/ytalarm/kernel/fake/FakeVideoRepository.kt
@@ -1,0 +1,75 @@
+package net.turtton.ytalarm.kernel.fake
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import net.turtton.ytalarm.kernel.entity.Video
+import net.turtton.ytalarm.kernel.repository.VideoRepository
+
+class FakeVideoRepository : VideoRepository<Unit> {
+    private val store = MutableStateFlow<List<Video>>(emptyList())
+    private var nextId = 1L
+
+    val currentData: List<Video> get() = store.value
+    val updateHistory: MutableList<Video> = mutableListOf()
+
+    fun seed(vararg videos: Video) {
+        store.value = videos.toList()
+        nextId = (videos.maxOfOrNull { it.id } ?: 0L) + 1
+        updateHistory.clear()
+    }
+
+    override fun getAll(executor: Unit): Flow<List<Video>> = store
+
+    override fun getFromIds(executor: Unit, ids: List<Long>): Flow<List<Video>> =
+        store.map { list -> list.filter { it.id in ids } }
+
+    override fun getFromVideoIds(executor: Unit, ids: List<String>): Flow<List<Video>> =
+        store.map { list -> list.filter { it.videoId in ids } }
+
+    override suspend fun getFromIdSync(executor: Unit, id: Long): Video? =
+        store.value.find { it.id == id }
+
+    override suspend fun getFromIdsSync(executor: Unit, ids: List<Long>): List<Video> =
+        store.value.filter { it.id in ids }
+
+    override suspend fun getExceptIdsSync(executor: Unit, ids: List<Long>): List<Video> =
+        store.value.filter { it.id !in ids }
+
+    override suspend fun getFromVideoIdSync(executor: Unit, id: String): Video? =
+        store.value.find { it.videoId == id }
+
+    override suspend fun getFromVideoIdsSync(executor: Unit, ids: List<String>): List<Video> =
+        store.value.filter { it.videoId in ids }
+
+    override suspend fun getExceptVideoIdsSync(executor: Unit, ids: List<String>): List<Video> =
+        store.value.filter { it.videoId !in ids }
+
+    override suspend fun update(executor: Unit, video: Video) {
+        updateHistory.add(video)
+        store.update { list -> list.map { if (it.id == video.id) video else it } }
+    }
+
+    override suspend fun insert(executor: Unit, video: Video): Long {
+        val id = nextId++
+        store.update { it + video.copy(id = id) }
+        return id
+    }
+
+    override suspend fun insertAll(executor: Unit, videos: List<Video>): List<Long> {
+        val ids = videos.map { nextId++ }
+        val stored = videos.zip(ids) { v, id -> v.copy(id = id) }
+        store.update { it + stored }
+        return ids
+    }
+
+    override suspend fun delete(executor: Unit, video: Video) {
+        store.update { list -> list.filter { it.id != video.id } }
+    }
+
+    override suspend fun deleteAll(executor: Unit, videos: List<Video>) {
+        val deleteIds = videos.map { it.id }.toSet()
+        store.update { list -> list.filter { it.id !in deleteIds } }
+    }
+}

--- a/usecase/build.gradle.kts
+++ b/usecase/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    `java-test-fixtures`
     alias(libs.plugins.kotlinter)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kover)
@@ -23,8 +24,12 @@ dependencies {
     implementation(libs.kotlinx.datetime)
     implementation(libs.bundles.arrow)
 
+    testFixturesImplementation(project(":kernel"))
+    testFixturesImplementation(testFixtures(project(":kernel")))
+
     testImplementation(libs.bundles.kotest)
-    testImplementation(libs.mockito.kotlin)
+    testImplementation(testFixtures(project(":kernel")))
+    testImplementation(testFixtures(project(":usecase")))
     testImplementation(libs.kotlinx.coroutines.test)
 }
 

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/AlarmUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/AlarmUseCaseTest.kt
@@ -34,7 +34,7 @@ class AlarmUseCaseTest :
         context("toggleAlarm") {
             test("disable alarm: update and reschedule") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.toggleAlarm(1L, false)
 
@@ -44,7 +44,7 @@ class AlarmUseCaseTest :
 
             test("enable alarm: update and reschedule") {
                 val alarm = Alarm(id = 1L, isEnabled = false)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.toggleAlarm(1L, true)
 
@@ -61,7 +61,7 @@ class AlarmUseCaseTest :
 
             test("disable last alarm: NoEnabledAlarm should not rollback") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
                 fakeScheduler.scheduleResult = Either.Left(AlarmScheduleError.NoEnabledAlarm)
 
                 val result = useCase.toggleAlarm(1L, false)
@@ -72,7 +72,7 @@ class AlarmUseCaseTest :
 
             test("schedule error other than NoEnabledAlarm: should rollback") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
                 fakeScheduler.scheduleResult = Either.Left(AlarmScheduleError.PermissionDenied)
 
                 val result = useCase.toggleAlarm(1L, false)
@@ -84,7 +84,7 @@ class AlarmUseCaseTest :
             test("disable one of multiple alarms: others remain enabled") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
                 val otherAlarm = Alarm(id = 2L, isEnabled = true)
-                fakeAlarmRepo.seed(alarm, otherAlarm)
+                fakeAlarmRepo.resetWith(alarm, otherAlarm)
 
                 val result = useCase.toggleAlarm(1L, false)
 
@@ -98,7 +98,7 @@ class AlarmUseCaseTest :
         context("processAfterFiring") {
             test("Once: disable alarm") {
                 val alarm = Alarm(id = 1L, repeatType = Alarm.RepeatType.Once, isEnabled = true)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.processAfterFiring(alarm)
 
@@ -107,7 +107,7 @@ class AlarmUseCaseTest :
 
             test("Everyday: keep enabled") {
                 val alarm = Alarm(id = 1L, repeatType = Alarm.RepeatType.Everyday, isEnabled = true)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.processAfterFiring(alarm)
 
@@ -116,7 +116,7 @@ class AlarmUseCaseTest :
 
             test("Snooze: delete alarm") {
                 val alarm = Alarm(id = 1L, repeatType = Alarm.RepeatType.Snooze, isEnabled = true)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.processAfterFiring(alarm)
 
@@ -130,7 +130,7 @@ class AlarmUseCaseTest :
                     repeatType = Alarm.RepeatType.Date(targetDate),
                     isEnabled = true
                 )
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.processAfterFiring(alarm)
 
@@ -146,7 +146,7 @@ class AlarmUseCaseTest :
                     repeatType = Alarm.RepeatType.Days(days),
                     isEnabled = true
                 )
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.processAfterFiring(alarm)
 
@@ -165,7 +165,7 @@ class AlarmUseCaseTest :
                     snoozeMinute = 10,
                     isEnabled = true
                 )
-                fakeAlarmRepo.seed(originalAlarm)
+                fakeAlarmRepo.resetWith(originalAlarm)
 
                 val either = useCase.createSnoozeAlarm(originalAlarm)
 
@@ -179,7 +179,7 @@ class AlarmUseCaseTest :
             test("deletes existing snooze alarms before creating new one") {
                 val existingSnooze = Alarm(id = 99L, repeatType = Alarm.RepeatType.Snooze)
                 val originalAlarm = Alarm(id = 1L, snoozeMinute = 5)
-                fakeAlarmRepo.seed(existingSnooze, originalAlarm)
+                fakeAlarmRepo.resetWith(existingSnooze, originalAlarm)
 
                 useCase.createSnoozeAlarm(originalAlarm)
 
@@ -199,7 +199,7 @@ class AlarmUseCaseTest :
 
             test("updates existing alarm and schedules") {
                 val alarm = Alarm(id = 5L)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.saveAlarmAndSchedule(alarm)
 
@@ -210,7 +210,7 @@ class AlarmUseCaseTest :
         context("deleteAlarmAndReschedule") {
             test("deletes alarm and reschedules") {
                 val alarm = Alarm(id = 1L)
-                fakeAlarmRepo.seed(alarm)
+                fakeAlarmRepo.resetWith(alarm)
 
                 useCase.deleteAlarmAndReschedule(alarm)
 
@@ -223,7 +223,7 @@ class AlarmUseCaseTest :
             test("returns only enabled alarms") {
                 val enabled = Alarm(id = 1L, isEnabled = true)
                 val disabled = Alarm(id = 2L, isEnabled = false)
-                fakeAlarmRepo.seed(enabled, disabled)
+                fakeAlarmRepo.resetWith(enabled, disabled)
 
                 val result = useCase.getEnabledAlarms()
 

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/AlarmUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/AlarmUseCaseTest.kt
@@ -7,161 +7,120 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
-import net.turtton.ytalarm.kernel.di.DataSource
-import net.turtton.ytalarm.kernel.di.DependsOnAlarmRepository
-import net.turtton.ytalarm.kernel.di.DependsOnDataSource
 import net.turtton.ytalarm.kernel.entity.Alarm
+import net.turtton.ytalarm.kernel.fake.FakeAlarmRepository
+import net.turtton.ytalarm.kernel.fake.FakeAlarmSchedulerPort
 import net.turtton.ytalarm.kernel.port.AlarmScheduleError
 import net.turtton.ytalarm.kernel.port.AlarmSchedulerPort
-import net.turtton.ytalarm.kernel.repository.AlarmRepository
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import net.turtton.ytalarm.usecase.fake.FakeLocalDataSourceContainer
 
 class AlarmUseCaseTest :
     FunSpec({
-        // テスト用のUnitExecutorを使った実装
-        lateinit var mockAlarmRepo: AlarmRepository<Unit>
-        lateinit var mockScheduler: AlarmSchedulerPort
-        lateinit var useCase: AlarmUseCase<Unit, TestAlarmLocalDS>
+        // テスト用のFake実装
+        lateinit var fakeAlarmRepo: FakeAlarmRepository
+        lateinit var fakeScheduler: FakeAlarmSchedulerPort
+        lateinit var useCase: AlarmUseCase<Unit, FakeLocalDataSourceContainer>
 
         beforeEach {
-            mockAlarmRepo = mock()
-            mockScheduler = mock()
-            whenever(mockScheduler.scheduleNextAlarm(any())).thenReturn(Either.Right(Unit))
-
-            val ds = TestAlarmLocalDS(mockAlarmRepo)
-            useCase = object : AlarmUseCase<Unit, TestAlarmLocalDS> {
-                override val localDataSource: TestAlarmLocalDS = ds
-                override val alarmScheduler: AlarmSchedulerPort = mockScheduler
+            fakeAlarmRepo = FakeAlarmRepository()
+            fakeScheduler = FakeAlarmSchedulerPort()
+            val ds = FakeLocalDataSourceContainer(alarmRepository = fakeAlarmRepo)
+            useCase = object : AlarmUseCase<Unit, FakeLocalDataSourceContainer> {
+                override val localDataSource: FakeLocalDataSourceContainer = ds
+                override val alarmScheduler: AlarmSchedulerPort = fakeScheduler
             }
         }
 
         context("toggleAlarm") {
             test("disable alarm: update and reschedule") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
-                whenever(mockAlarmRepo.getFromId(Unit, 1L)).thenReturn(alarm)
-                whenever(
-                    mockAlarmRepo.getAllSync(Unit)
-                ).thenReturn(listOf(alarm.copy(isEnabled = false)))
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.toggleAlarm(1L, false)
 
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe false
-                verify(mockScheduler).scheduleNextAlarm(any())
+                fakeAlarmRepo.currentData.first { it.id == 1L }.isEnabled shouldBe false
+                fakeScheduler.scheduledCalls shouldHaveSize 1
             }
 
             test("enable alarm: update and reschedule") {
                 val alarm = Alarm(id = 1L, isEnabled = false)
-                whenever(mockAlarmRepo.getFromId(Unit, 1L)).thenReturn(alarm)
-                whenever(
-                    mockAlarmRepo.getAllSync(Unit)
-                ).thenReturn(listOf(alarm.copy(isEnabled = true)))
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.toggleAlarm(1L, true)
 
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe true
-                verify(mockScheduler).scheduleNextAlarm(any())
+                fakeAlarmRepo.currentData.first { it.id == 1L }.isEnabled shouldBe true
+                fakeScheduler.scheduledCalls shouldHaveSize 1
             }
 
             test("alarm not found: do nothing") {
-                whenever(mockAlarmRepo.getFromId(Unit, 99L)).thenReturn(null)
-
                 useCase.toggleAlarm(99L, true)
 
-                verify(mockAlarmRepo, never()).update(any(), any())
-                verify(mockScheduler, never()).scheduleNextAlarm(any())
+                fakeAlarmRepo.currentData shouldBe emptyList()
+                fakeScheduler.scheduledCalls shouldHaveSize 0
             }
 
             test("disable last alarm: NoEnabledAlarm should not rollback") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
-                whenever(mockAlarmRepo.getFromId(Unit, 1L)).thenReturn(alarm)
-                whenever(mockAlarmRepo.getAllSync(Unit))
-                    .thenReturn(listOf(alarm.copy(isEnabled = false)))
-                whenever(mockScheduler.scheduleNextAlarm(any()))
-                    .thenReturn(Either.Left(AlarmScheduleError.NoEnabledAlarm))
+                fakeAlarmRepo.seed(alarm)
+                fakeScheduler.scheduleResult = Either.Left(AlarmScheduleError.NoEnabledAlarm)
 
                 val result = useCase.toggleAlarm(1L, false)
 
                 result.shouldBeInstanceOf<Either.Left<AlarmScheduleError.NoEnabledAlarm>>()
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo, times(1)).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe false
+                fakeAlarmRepo.currentData.first { it.id == 1L }.isEnabled shouldBe false
             }
 
             test("schedule error other than NoEnabledAlarm: should rollback") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
-                whenever(mockAlarmRepo.getFromId(Unit, 1L)).thenReturn(alarm)
-                whenever(mockAlarmRepo.getAllSync(Unit))
-                    .thenReturn(listOf(alarm.copy(isEnabled = false)))
-                whenever(mockScheduler.scheduleNextAlarm(any()))
-                    .thenReturn(Either.Left(AlarmScheduleError.PermissionDenied))
+                fakeAlarmRepo.seed(alarm)
+                fakeScheduler.scheduleResult = Either.Left(AlarmScheduleError.PermissionDenied)
 
                 val result = useCase.toggleAlarm(1L, false)
 
                 result.shouldBeInstanceOf<Either.Left<AlarmScheduleError.PermissionDenied>>()
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo, times(2)).update(any(), captor.capture())
-                captor.allValues[0].isEnabled shouldBe false
-                captor.allValues[1] shouldBe alarm
+                fakeAlarmRepo.currentData.first { it.id == 1L } shouldBe alarm
             }
 
             test("disable one of multiple alarms: others remain enabled") {
                 val alarm = Alarm(id = 1L, isEnabled = true)
                 val otherAlarm = Alarm(id = 2L, isEnabled = true)
-                whenever(mockAlarmRepo.getFromId(Unit, 1L)).thenReturn(alarm)
-                whenever(mockAlarmRepo.getAllSync(Unit))
-                    .thenReturn(listOf(alarm.copy(isEnabled = false), otherAlarm))
+                fakeAlarmRepo.seed(alarm, otherAlarm)
 
                 val result = useCase.toggleAlarm(1L, false)
 
                 result.shouldBeInstanceOf<Either.Right<Unit>>()
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo, times(1)).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe false
-                verify(mockScheduler).scheduleNextAlarm(any())
+                fakeAlarmRepo.currentData.first { it.id == 1L }.isEnabled shouldBe false
+                fakeAlarmRepo.currentData.first { it.id == 2L }.isEnabled shouldBe true
+                fakeScheduler.scheduledCalls shouldHaveSize 1
             }
         }
 
         context("processAfterFiring") {
             test("Once: disable alarm") {
                 val alarm = Alarm(id = 1L, repeatType = Alarm.RepeatType.Once, isEnabled = true)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(emptyList())
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.processAfterFiring(alarm)
 
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe false
+                fakeAlarmRepo.currentData.first { it.id == 1L }.isEnabled shouldBe false
             }
 
             test("Everyday: keep enabled") {
                 val alarm = Alarm(id = 1L, repeatType = Alarm.RepeatType.Everyday, isEnabled = true)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(listOf(alarm))
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.processAfterFiring(alarm)
 
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe true
+                fakeAlarmRepo.currentData.first { it.id == 1L }.isEnabled shouldBe true
             }
 
             test("Snooze: delete alarm") {
                 val alarm = Alarm(id = 1L, repeatType = Alarm.RepeatType.Snooze, isEnabled = true)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(emptyList())
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.processAfterFiring(alarm)
 
-                verify(mockAlarmRepo).delete(any(), any())
-                verify(mockAlarmRepo, never()).update(any(), any())
+                fakeAlarmRepo.currentData.none { it.id == 1L } shouldBe true
             }
 
             test("Date: convert to Once and disable") {
@@ -171,14 +130,13 @@ class AlarmUseCaseTest :
                     repeatType = Alarm.RepeatType.Date(targetDate),
                     isEnabled = true
                 )
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(emptyList())
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.processAfterFiring(alarm)
 
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe false
-                captor.firstValue.repeatType shouldBe Alarm.RepeatType.Once
+                val updated = fakeAlarmRepo.currentData.first { it.id == 1L }
+                updated.isEnabled shouldBe false
+                updated.repeatType shouldBe Alarm.RepeatType.Once
             }
 
             test("Days: keep enabled") {
@@ -188,14 +146,13 @@ class AlarmUseCaseTest :
                     repeatType = Alarm.RepeatType.Days(days),
                     isEnabled = true
                 )
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(listOf(alarm))
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.processAfterFiring(alarm)
 
-                val captor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo).update(any(), captor.capture())
-                captor.firstValue.isEnabled shouldBe true
-                captor.firstValue.repeatType shouldBe Alarm.RepeatType.Days(days)
+                val updated = fakeAlarmRepo.currentData.first { it.id == 1L }
+                updated.isEnabled shouldBe true
+                updated.repeatType shouldBe Alarm.RepeatType.Days(days)
             }
         }
 
@@ -208,11 +165,7 @@ class AlarmUseCaseTest :
                     snoozeMinute = 10,
                     isEnabled = true
                 )
-                // 既存スヌーズなし
-                whenever(mockAlarmRepo.getMatched(Unit, Alarm.RepeatType.Snooze))
-                    .thenReturn(emptyList())
-                whenever(mockAlarmRepo.insert(any(), any())).thenReturn(100L)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(emptyList())
+                fakeAlarmRepo.seed(originalAlarm)
 
                 val either = useCase.createSnoozeAlarm(originalAlarm)
 
@@ -220,55 +173,49 @@ class AlarmUseCaseTest :
                 val result = either.value
                 result.repeatType shouldBe Alarm.RepeatType.Snooze
                 result.isEnabled shouldBe true
-                result.id shouldBe 100L
+                result.id shouldBe 2L
             }
 
             test("deletes existing snooze alarms before creating new one") {
                 val existingSnooze = Alarm(id = 99L, repeatType = Alarm.RepeatType.Snooze)
-                whenever(mockAlarmRepo.getMatched(Unit, Alarm.RepeatType.Snooze))
-                    .thenReturn(listOf(existingSnooze))
-                whenever(mockAlarmRepo.insert(any(), any())).thenReturn(100L)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(emptyList())
-
                 val originalAlarm = Alarm(id = 1L, snoozeMinute = 5)
+                fakeAlarmRepo.seed(existingSnooze, originalAlarm)
+
                 useCase.createSnoozeAlarm(originalAlarm)
 
-                verify(mockAlarmRepo).delete(any(), any())
+                fakeAlarmRepo.currentData.none { it.id == 99L } shouldBe true
             }
         }
 
         context("saveAlarmAndSchedule") {
             test("inserts new alarm and schedules") {
                 val alarm = Alarm(id = 0L)
-                whenever(mockAlarmRepo.insert(any(), any())).thenReturn(1L)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(listOf(alarm.copy(id = 1L)))
 
                 useCase.saveAlarmAndSchedule(alarm)
 
-                verify(mockAlarmRepo).insert(any(), any())
-                verify(mockScheduler).scheduleNextAlarm(any())
+                fakeAlarmRepo.currentData shouldHaveSize 1
+                fakeScheduler.scheduledCalls shouldHaveSize 1
             }
 
             test("updates existing alarm and schedules") {
                 val alarm = Alarm(id = 5L)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(listOf(alarm))
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.saveAlarmAndSchedule(alarm)
 
-                verify(mockAlarmRepo).update(any(), any())
-                verify(mockScheduler).scheduleNextAlarm(any())
+                fakeScheduler.scheduledCalls shouldHaveSize 1
             }
         }
 
         context("deleteAlarmAndReschedule") {
             test("deletes alarm and reschedules") {
                 val alarm = Alarm(id = 1L)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(emptyList())
+                fakeAlarmRepo.seed(alarm)
 
                 useCase.deleteAlarmAndReschedule(alarm)
 
-                verify(mockAlarmRepo).delete(any(), any())
-                verify(mockScheduler).scheduleNextAlarm(any())
+                fakeAlarmRepo.currentData.none { it.id == 1L } shouldBe true
+                fakeScheduler.scheduledCalls shouldHaveSize 1
             }
         }
 
@@ -276,7 +223,7 @@ class AlarmUseCaseTest :
             test("returns only enabled alarms") {
                 val enabled = Alarm(id = 1L, isEnabled = true)
                 val disabled = Alarm(id = 2L, isEnabled = false)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(listOf(enabled, disabled))
+                fakeAlarmRepo.seed(enabled, disabled)
 
                 val result = useCase.getEnabledAlarms()
 
@@ -285,12 +232,3 @@ class AlarmUseCaseTest :
             }
         }
     })
-
-// テスト用のLocalDataSource実装
-class TestAlarmLocalDS(override val alarmRepository: AlarmRepository<Unit>) :
-    DependsOnAlarmRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/DownloadUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/DownloadUseCaseTest.kt
@@ -57,7 +57,7 @@ class DownloadUseCaseTest :
                     videoId = "v1",
                     state = Video.State.Downloaded("downloads/1.mp4", 1000L, true)
                 )
-                fakeVideoRepo.seed(video)
+                fakeVideoRepo.resetWith(video)
 
                 val result = useCase.downloadVideo(1L)
 
@@ -73,7 +73,7 @@ class DownloadUseCaseTest :
                     videoUrl = "http://example.com/video",
                     state = Video.State.Downloading
                 )
-                fakeVideoRepo.seed(video)
+                fakeVideoRepo.resetWith(video)
                 fakeDownloadRepo.downloadResponses["http://example.com/video"] =
                     Either.Right(
                         DownloadResult(
@@ -95,7 +95,7 @@ class DownloadUseCaseTest :
                     videoUrl = "http://example.com/video",
                     state = Video.State.Information(isStreamable = true)
                 )
-                fakeVideoRepo.seed(video)
+                fakeVideoRepo.resetWith(video)
                 fakeDownloadRepo.downloadResponses["http://example.com/video"] =
                     Either.Right(
                         DownloadResult(
@@ -133,7 +133,7 @@ class DownloadUseCaseTest :
                     videoUrl = "http://example.com/video",
                     state = Video.State.Information(isStreamable = false)
                 )
-                fakeVideoRepo.seed(video)
+                fakeVideoRepo.resetWith(video)
                 fakeDownloadRepo.downloadResponses["http://example.com/video"] =
                     Either.Left(DownloadError.NetworkError(RuntimeException("timeout")))
 
@@ -175,7 +175,7 @@ class DownloadUseCaseTest :
                     videoId = "v2",
                     state = Video.State.Information(isStreamable = true)
                 )
-                fakeVideoRepo.seed(downloadedVideo, infoVideo)
+                fakeVideoRepo.resetWith(downloadedVideo, infoVideo)
                 fakeFileStorage.existingFiles.add("downloads/1.mp4")
                 fakeFileStorage.totalSize = 5000L
 

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/DownloadUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/DownloadUseCaseTest.kt
@@ -4,51 +4,48 @@ import arrow.core.Either
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import net.turtton.ytalarm.kernel.di.DataSource
-import net.turtton.ytalarm.kernel.di.DependsOnDataSource
-import net.turtton.ytalarm.kernel.di.DependsOnVideoDownloadRepository
-import net.turtton.ytalarm.kernel.di.DependsOnVideoRepository
 import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.kernel.error.DownloadError
 import net.turtton.ytalarm.kernel.error.DownloadResult
+import net.turtton.ytalarm.kernel.fake.FakeFileStoragePort
+import net.turtton.ytalarm.kernel.fake.FakeVideoDownloadRepository
+import net.turtton.ytalarm.kernel.fake.FakeVideoDownloadRepository.DownloadRequest
+import net.turtton.ytalarm.kernel.fake.FakeVideoRepository
 import net.turtton.ytalarm.kernel.port.FileStoragePort
-import net.turtton.ytalarm.kernel.repository.VideoDownloadRepository
-import net.turtton.ytalarm.kernel.repository.VideoRepository
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import net.turtton.ytalarm.usecase.fake.FakeLocalDataSourceContainer
+import net.turtton.ytalarm.usecase.fake.FakeRemoteDataSourceContainer
 import java.io.File
 
 class DownloadUseCaseTest :
     FunSpec({
-        lateinit var mockVideoRepo: VideoRepository<Unit>
-        lateinit var mockDownloadRepo: VideoDownloadRepository<Unit>
-        lateinit var mockFileStorage: FileStoragePort
-        lateinit var useCase: DownloadUseCase<Unit, Unit, TestDlLocalDS, TestDlRemoteDS>
+        lateinit var fakeVideoRepo: FakeVideoRepository
+        lateinit var fakeDownloadRepo: FakeVideoDownloadRepository
+        lateinit var fakeFileStorage: FakeFileStoragePort
+        lateinit var useCase:
+            DownloadUseCase<Unit, Unit, FakeLocalDataSourceContainer, FakeRemoteDataSourceContainer>
 
         beforeEach {
-            mockVideoRepo = mock()
-            mockDownloadRepo = mock()
-            mockFileStorage = mock()
-
-            val localDs = TestDlLocalDS(mockVideoRepo)
-            val remoteDs = TestDlRemoteDS(mockDownloadRepo)
+            fakeVideoRepo = FakeVideoRepository()
+            fakeDownloadRepo = FakeVideoDownloadRepository()
+            fakeFileStorage = FakeFileStoragePort()
+            val localDs = FakeLocalDataSourceContainer(videoRepository = fakeVideoRepo)
+            val remoteDs = FakeRemoteDataSourceContainer(videoDownloadRepository = fakeDownloadRepo)
             useCase =
-                object : DownloadUseCase<Unit, Unit, TestDlLocalDS, TestDlRemoteDS> {
-                    override val localDataSource: TestDlLocalDS = localDs
-                    override val remoteDataSource: TestDlRemoteDS = remoteDs
-                    override val fileStorage: FileStoragePort = mockFileStorage
+                object :
+                    DownloadUseCase<
+                        Unit,
+                        Unit,
+                        FakeLocalDataSourceContainer,
+                        FakeRemoteDataSourceContainer
+                        > {
+                    override val localDataSource: FakeLocalDataSourceContainer = localDs
+                    override val remoteDataSource: FakeRemoteDataSourceContainer = remoteDs
+                    override val fileStorage: FileStoragePort = fakeFileStorage
                 }
         }
 
         context("downloadVideo") {
             test("returns null when video not found") {
-                whenever(mockVideoRepo.getFromIdSync(any(), eq(999L))).thenReturn(null)
-
                 val result = useCase.downloadVideo(999L)
 
                 result shouldBe null
@@ -60,12 +57,13 @@ class DownloadUseCaseTest :
                     videoId = "v1",
                     state = Video.State.Downloaded("downloads/1.mp4", 1000L, true)
                 )
-                whenever(mockVideoRepo.getFromIdSync(any(), eq(1L))).thenReturn(video)
+                fakeVideoRepo.seed(video)
 
                 val result = useCase.downloadVideo(1L)
 
                 result shouldBe null
-                verify(mockVideoRepo, never()).update(any(), any())
+                fakeVideoRepo.currentData.find { it.id == 1L }?.state shouldBe
+                    Video.State.Downloaded("downloads/1.mp4", 1000L, true)
             }
 
             test("retries download for stuck Downloading video") {
@@ -75,22 +73,14 @@ class DownloadUseCaseTest :
                     videoUrl = "http://example.com/video",
                     state = Video.State.Downloading
                 )
-                val downloadDir =
-                    File(System.getProperty("java.io.tmpdir"), "test-downloads")
-                val dlResult =
-                    DownloadResult("${downloadDir.absolutePath}/1.mp4", 3000L)
-
-                whenever(mockVideoRepo.getFromIdSync(any(), eq(1L))).thenReturn(video)
-                whenever(mockFileStorage.getDownloadDir()).thenReturn(downloadDir)
-                whenever(
-                    mockDownloadRepo.downloadVideo(
-                        any(),
-                        any(),
-                        any(),
-                        any(),
-                        any()
+                fakeVideoRepo.seed(video)
+                fakeDownloadRepo.downloadResponses["http://example.com/video"] =
+                    Either.Right(
+                        DownloadResult(
+                            "${fakeFileStorage.getDownloadDir().absolutePath}/1.mp4",
+                            3000L
+                        )
                     )
-                ).thenReturn(Either.Right(dlResult))
 
                 val result = useCase.downloadVideo(1L)
 
@@ -105,35 +95,35 @@ class DownloadUseCaseTest :
                     videoUrl = "http://example.com/video",
                     state = Video.State.Information(isStreamable = true)
                 )
-                val downloadDir = File(System.getProperty("java.io.tmpdir"), "test-downloads")
-                val dlResult = DownloadResult("${downloadDir.absolutePath}/1.mp4", 5000L)
-
-                whenever(mockVideoRepo.getFromIdSync(any(), eq(1L))).thenReturn(video)
-                whenever(mockFileStorage.getDownloadDir()).thenReturn(downloadDir)
-                whenever(
-                    mockDownloadRepo.downloadVideo(
-                        any(),
-                        eq("http://example.com/video"),
-                        eq("${downloadDir.absolutePath}/1.%(ext)s"),
-                        eq(DownloadUseCase.DEFAULT_FORMAT_SELECTOR),
-                        any()
+                fakeVideoRepo.seed(video)
+                fakeDownloadRepo.downloadResponses["http://example.com/video"] =
+                    Either.Right(
+                        DownloadResult(
+                            "${fakeFileStorage.getDownloadDir().absolutePath}/1.mp4",
+                            5000L
+                        )
                     )
-                ).thenReturn(Either.Right(dlResult))
 
                 val result = useCase.downloadVideo(1L)
 
                 result.shouldBeInstanceOf<Either.Right<DownloadResult>>()
                 result.getOrNull()?.fileSize shouldBe 5000L
 
-                val captor = argumentCaptor<Video>()
-                // 2回のupdate: Downloading状態への遷移 + Downloaded状態への遷移
-                verify(mockVideoRepo, org.mockito.kotlin.times(2)).update(any(), captor.capture())
-                captor.firstValue.state shouldBe Video.State.Downloading
-                captor.secondValue.state shouldBe Video.State.Downloaded(
-                    "downloads/1.mp4",
-                    5000L,
-                    true
+                fakeVideoRepo.updateHistory.size shouldBe 2
+                fakeVideoRepo.updateHistory[0].state shouldBe Video.State.Downloading
+
+                fakeDownloadRepo.downloadRequests.size shouldBe 1
+                val req = fakeDownloadRepo.downloadRequests.first()
+                req shouldBe DownloadRequest(
+                    videoUrl = "http://example.com/video",
+                    outputPath =
+                        "${fakeFileStorage.getDownloadDir().absolutePath}/1.%(ext)s",
+                    formatSelector = DownloadUseCase.DEFAULT_FORMAT_SELECTOR
                 )
+
+                val updatedVideo = fakeVideoRepo.currentData.find { it.id == 1L }
+                updatedVideo?.state shouldBe
+                    Video.State.Downloaded("downloads/1.mp4", 5000L, true)
             }
 
             test("failed download reverts to Information") {
@@ -143,39 +133,32 @@ class DownloadUseCaseTest :
                     videoUrl = "http://example.com/video",
                     state = Video.State.Information(isStreamable = false)
                 )
-                val downloadDir = File(System.getProperty("java.io.tmpdir"), "test-downloads")
-                val error = DownloadError.NetworkError(RuntimeException("timeout"))
-
-                whenever(mockVideoRepo.getFromIdSync(any(), eq(1L))).thenReturn(video)
-                whenever(mockFileStorage.getDownloadDir()).thenReturn(downloadDir)
-                whenever(
-                    mockDownloadRepo.downloadVideo(any(), any(), any(), any(), any())
-                ).thenReturn(Either.Left(error))
+                fakeVideoRepo.seed(video)
+                fakeDownloadRepo.downloadResponses["http://example.com/video"] =
+                    Either.Left(DownloadError.NetworkError(RuntimeException("timeout")))
 
                 val result = useCase.downloadVideo(1L)
 
                 result.shouldBeInstanceOf<Either.Left<DownloadError>>()
 
-                val captor = argumentCaptor<Video>()
-                verify(mockVideoRepo, org.mockito.kotlin.times(2)).update(any(), captor.capture())
-                captor.firstValue.state shouldBe Video.State.Downloading
-                captor.secondValue.state shouldBe Video.State.Information(isStreamable = false)
+                val updatedVideo = fakeVideoRepo.currentData.find { it.id == 1L }
+                updatedVideo?.state shouldBe Video.State.Information(isStreamable = false)
             }
         }
 
         context("canDownload") {
             test("returns true when under limit") {
-                whenever(mockFileStorage.getTotalDownloadSize()).thenReturn(500L)
+                fakeFileStorage.totalSize = 500L
                 useCase.canDownload(1000L) shouldBe true
             }
 
             test("returns false when at limit") {
-                whenever(mockFileStorage.getTotalDownloadSize()).thenReturn(1000L)
+                fakeFileStorage.totalSize = 1000L
                 useCase.canDownload(1000L) shouldBe false
             }
 
             test("returns false when over limit") {
-                whenever(mockFileStorage.getTotalDownloadSize()).thenReturn(1500L)
+                fakeFileStorage.totalSize = 1500L
                 useCase.canDownload(1000L) shouldBe false
             }
         }
@@ -192,41 +175,24 @@ class DownloadUseCaseTest :
                     videoId = "v2",
                     state = Video.State.Information(isStreamable = true)
                 )
-                whenever(mockVideoRepo.getExceptIdsSync(any(), eq(emptyList()))).thenReturn(
-                    listOf(downloadedVideo, infoVideo)
-                )
-                whenever(mockFileStorage.deleteAllDownloads()).thenReturn(1L)
+                fakeVideoRepo.seed(downloadedVideo, infoVideo)
+                fakeFileStorage.existingFiles.add("downloads/1.mp4")
+                fakeFileStorage.totalSize = 5000L
 
                 val deletedCount = useCase.deleteAllDownloads()
 
                 deletedCount shouldBe 1L
-                val captor = argumentCaptor<Video>()
-                verify(mockVideoRepo).update(any(), captor.capture())
-                captor.firstValue.id shouldBe 1L
-                captor.firstValue.state shouldBe Video.State.Information(isStreamable = true)
+                val updatedVideo = fakeVideoRepo.currentData.find { it.id == 1L }
+                updatedVideo?.state shouldBe Video.State.Information(isStreamable = true)
+                val unchangedVideo = fakeVideoRepo.currentData.find { it.id == 2L }
+                unchangedVideo?.state shouldBe Video.State.Information(isStreamable = true)
             }
         }
 
         context("getTotalDownloadSize") {
             test("delegates to fileStorage") {
-                whenever(mockFileStorage.getTotalDownloadSize()).thenReturn(42L)
+                fakeFileStorage.totalSize = 42L
                 useCase.getTotalDownloadSize() shouldBe 42L
             }
         }
     })
-
-class TestDlLocalDS(override val videoRepository: VideoRepository<Unit>) :
-    DependsOnVideoRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}
-
-class TestDlRemoteDS(override val videoDownloadRepository: VideoDownloadRepository<Unit>) :
-    DependsOnVideoDownloadRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/ImportUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/ImportUseCaseTest.kt
@@ -53,7 +53,7 @@ class ImportUseCaseTest :
                         domain = "example.com",
                         state = Video.State.Information()
                     )
-                fakeVideoRepo.seed(existingVideo)
+                fakeVideoRepo.resetWith(existingVideo)
 
                 val result = useCase.checkVideoDuplication("vid1", "example.com")
 
@@ -68,7 +68,7 @@ class ImportUseCaseTest :
                         domain = "other.com",
                         state = Video.State.Information()
                     )
-                fakeVideoRepo.seed(existingVideo)
+                fakeVideoRepo.resetWith(existingVideo)
 
                 val result = useCase.checkVideoDuplication("vid1", "example.com")
 
@@ -122,7 +122,7 @@ class ImportUseCaseTest :
                     domain = "example.com",
                     state = Video.State.Information()
                 )
-                fakeVideoRepo.seed(existingVideo)
+                fakeVideoRepo.resetWith(existingVideo)
                 fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
                     Either.Right(videoInfo)
 
@@ -152,8 +152,8 @@ class ImportUseCaseTest :
                         Playlist.SyncRule.ALWAYS_ADD
                     )
                 )
-                fakePlaylistRepo.seed(playlist)
-                fakeVideoRepo.seed(
+                fakePlaylistRepo.resetWith(playlist)
+                fakeVideoRepo.resetWith(
                     Video(id = 1L, videoId = "existing1", state = Video.State.Information()),
                     Video(id = 2L, videoId = "existing2", state = Video.State.Information())
                 )
@@ -180,8 +180,8 @@ class ImportUseCaseTest :
                     ),
                     thumbnail = Playlist.Thumbnail.Video(1L)
                 )
-                fakePlaylistRepo.seed(playlist)
-                fakeVideoRepo.seed(
+                fakePlaylistRepo.resetWith(playlist)
+                fakeVideoRepo.resetWith(
                     Video(id = 1L, videoId = "existing1", state = Video.State.Information()),
                     Video(id = 2L, videoId = "existing2", state = Video.State.Information())
                 )

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/ImportUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/ImportUseCaseTest.kt
@@ -3,43 +3,45 @@ package net.turtton.ytalarm.usecase
 import arrow.core.Either
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import net.turtton.ytalarm.kernel.di.DataSource
-import net.turtton.ytalarm.kernel.di.DependsOnDataSource
-import net.turtton.ytalarm.kernel.di.DependsOnPlaylistRepository
-import net.turtton.ytalarm.kernel.di.DependsOnVideoInfoRepository
-import net.turtton.ytalarm.kernel.di.DependsOnVideoRepository
 import net.turtton.ytalarm.kernel.dto.VideoInformation
 import net.turtton.ytalarm.kernel.entity.Playlist
 import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.kernel.error.VideoInfoError
-import net.turtton.ytalarm.kernel.repository.PlaylistRepository
-import net.turtton.ytalarm.kernel.repository.VideoInfoRepository
-import net.turtton.ytalarm.kernel.repository.VideoRepository
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import net.turtton.ytalarm.kernel.fake.FakePlaylistRepository
+import net.turtton.ytalarm.kernel.fake.FakeVideoInfoRepository
+import net.turtton.ytalarm.kernel.fake.FakeVideoRepository
+import net.turtton.ytalarm.usecase.fake.FakeLocalDataSourceContainer
+import net.turtton.ytalarm.usecase.fake.FakeRemoteDataSourceContainer
 
 class ImportUseCaseTest :
     FunSpec({
-        lateinit var mockVideoRepo: VideoRepository<Unit>
-        lateinit var mockPlaylistRepo: PlaylistRepository<Unit>
-        lateinit var mockVideoInfoRepo: VideoInfoRepository<Unit>
-        lateinit var useCase: ImportUseCase<Unit, Unit, TestImportLocalDS, TestImportRemoteDS>
+        lateinit var fakeVideoRepo: FakeVideoRepository
+        lateinit var fakePlaylistRepo: FakePlaylistRepository
+        lateinit var fakeVideoInfoRepo: FakeVideoInfoRepository
+        lateinit var useCase:
+            ImportUseCase<Unit, Unit, FakeLocalDataSourceContainer, FakeRemoteDataSourceContainer>
 
         beforeEach {
-            mockVideoRepo = mock()
-            mockPlaylistRepo = mock()
-            mockVideoInfoRepo = mock()
-
-            val localDs = TestImportLocalDS(mockVideoRepo, mockPlaylistRepo)
-            val remoteDs = TestImportRemoteDS(mockVideoInfoRepo)
-            useCase = object : ImportUseCase<Unit, Unit, TestImportLocalDS, TestImportRemoteDS> {
-                override val localDataSource: TestImportLocalDS = localDs
-                override val remoteDataSource: TestImportRemoteDS = remoteDs
-            }
+            fakeVideoRepo = FakeVideoRepository()
+            fakePlaylistRepo = FakePlaylistRepository()
+            fakeVideoInfoRepo = FakeVideoInfoRepository()
+            val localDs = FakeLocalDataSourceContainer(
+                videoRepository = fakeVideoRepo,
+                playlistRepository = fakePlaylistRepo
+            )
+            val remoteDs =
+                FakeRemoteDataSourceContainer(videoInfoRepository = fakeVideoInfoRepo)
+            useCase =
+                object :
+                    ImportUseCase<
+                        Unit,
+                        Unit,
+                        FakeLocalDataSourceContainer,
+                        FakeRemoteDataSourceContainer
+                        > {
+                    override val localDataSource: FakeLocalDataSourceContainer = localDs
+                    override val remoteDataSource: FakeRemoteDataSourceContainer = remoteDs
+                }
         }
 
         context("checkVideoDuplication") {
@@ -51,7 +53,7 @@ class ImportUseCaseTest :
                         domain = "example.com",
                         state = Video.State.Information()
                     )
-                whenever(mockVideoRepo.getFromVideoIdSync(Unit, "vid1")).thenReturn(existingVideo)
+                fakeVideoRepo.seed(existingVideo)
 
                 val result = useCase.checkVideoDuplication("vid1", "example.com")
 
@@ -66,7 +68,7 @@ class ImportUseCaseTest :
                         domain = "other.com",
                         state = Video.State.Information()
                     )
-                whenever(mockVideoRepo.getFromVideoIdSync(Unit, "vid1")).thenReturn(existingVideo)
+                fakeVideoRepo.seed(existingVideo)
 
                 val result = useCase.checkVideoDuplication("vid1", "example.com")
 
@@ -74,8 +76,6 @@ class ImportUseCaseTest :
             }
 
             test("no existing video: returns null") {
-                whenever(mockVideoRepo.getFromVideoIdSync(Unit, "vid1")).thenReturn(null)
-
                 val result = useCase.checkVideoDuplication("vid1", "example.com")
 
                 result shouldBe null
@@ -95,16 +95,13 @@ class ImportUseCaseTest :
                         videoUrl = "http://example.com/video.mp4"
                     )
                 )
-                whenever(
-                    mockVideoInfoRepo.fetchVideoInfo(Unit, "http://example.com/video")
-                ).thenReturn(Either.Right(videoInfo))
-                whenever(mockVideoRepo.getFromVideoIdSync(Unit, "vid1")).thenReturn(null)
-                whenever(mockVideoRepo.insert(any(), any())).thenReturn(1L)
+                fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
+                    Either.Right(videoInfo)
 
                 val result = useCase.fetchAndImportVideo("http://example.com/video")
 
                 result shouldBe ImportResult.Success(1L)
-                verify(mockVideoRepo).insert(any(), any())
+                fakeVideoRepo.currentData.size shouldBe 1
             }
 
             test("duplicate video: returns existing id") {
@@ -125,23 +122,19 @@ class ImportUseCaseTest :
                     domain = "example.com",
                     state = Video.State.Information()
                 )
-                whenever(
-                    mockVideoInfoRepo.fetchVideoInfo(Unit, "http://example.com/video")
-                ).thenReturn(Either.Right(videoInfo))
-                whenever(mockVideoRepo.getFromVideoIdSync(Unit, "vid1")).thenReturn(existingVideo)
+                fakeVideoRepo.seed(existingVideo)
+                fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
+                    Either.Right(videoInfo)
 
                 val result = useCase.fetchAndImportVideo("http://example.com/video")
 
                 result shouldBe ImportResult.Duplicate(42L)
-                verify(mockVideoRepo, never()).insert(any(), any())
+                fakeVideoRepo.currentData.size shouldBe 1
             }
 
             test("network error: returns failure") {
-                whenever(
-                    mockVideoInfoRepo.fetchVideoInfo(Unit, "http://example.com/video")
-                ).thenReturn(
+                fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
                     Either.Left(VideoInfoError.NetworkError(RuntimeException("network error")))
-                )
 
                 val result = useCase.fetchAndImportVideo("http://example.com/video")
 
@@ -159,21 +152,22 @@ class ImportUseCaseTest :
                         Playlist.SyncRule.ALWAYS_ADD
                     )
                 )
+                fakePlaylistRepo.seed(playlist)
+                fakeVideoRepo.seed(
+                    Video(id = 1L, videoId = "existing1", state = Video.State.Information()),
+                    Video(id = 2L, videoId = "existing2", state = Video.State.Information())
+                )
                 val newVideo1 = VideoInformation(
                     id = "vid3",
                     url = "http://example.com/vid3",
                     domain = "example.com",
                     typeData = VideoInformation.Type.Video("V3", "", "")
                 )
-                whenever(mockVideoRepo.getFromVideoIdSync(Unit, "vid3")).thenReturn(null)
-                whenever(mockVideoRepo.insert(any(), any())).thenReturn(3L)
 
                 useCase.syncCloudPlaylist(playlist, listOf(newVideo1))
 
-                val captor = argumentCaptor<Playlist>()
-                verify(mockPlaylistRepo).update(any(), captor.capture())
-                // videos should include existing (1L, 2L) + new (3L)
-                captor.firstValue.videos.containsAll(listOf(1L, 2L, 3L)) shouldBe true
+                val updatedPlaylist = fakePlaylistRepo.currentData.find { it.id == 1L }
+                updatedPlaylist?.videos?.containsAll(listOf(1L, 2L, 3L)) shouldBe true
             }
 
             test("DELETE_IF_NOT_EXIST: replaces videos with new set") {
@@ -186,43 +180,23 @@ class ImportUseCaseTest :
                     ),
                     thumbnail = Playlist.Thumbnail.Video(1L)
                 )
+                fakePlaylistRepo.seed(playlist)
+                fakeVideoRepo.seed(
+                    Video(id = 1L, videoId = "existing1", state = Video.State.Information()),
+                    Video(id = 2L, videoId = "existing2", state = Video.State.Information())
+                )
                 val newVideo = VideoInformation(
                     id = "vid3",
                     url = "http://example.com/vid3",
                     domain = "example.com",
                     typeData = VideoInformation.Type.Video("V3", "", "")
                 )
-                whenever(mockVideoRepo.getFromVideoIdSync(Unit, "vid3")).thenReturn(null)
-                whenever(mockVideoRepo.insert(any(), any())).thenReturn(3L)
 
                 useCase.syncCloudPlaylist(playlist, listOf(newVideo))
 
-                val captor = argumentCaptor<Playlist>()
-                verify(mockPlaylistRepo).update(any(), captor.capture())
-                // Should only have the new video
-                captor.firstValue.videos shouldBe listOf(3L)
-                // Thumbnail should be updated since old thumbnail (vid 1) no longer exists
-                captor.firstValue.thumbnail shouldBe Playlist.Thumbnail.Video(3L)
+                val updatedPlaylist = fakePlaylistRepo.currentData.find { it.id == 1L }
+                updatedPlaylist?.videos shouldBe listOf(3L)
+                updatedPlaylist?.thumbnail shouldBe Playlist.Thumbnail.Video(3L)
             }
         }
     })
-
-// テスト用DataSource実装
-class TestImportLocalDS(
-    override val videoRepository: VideoRepository<Unit>,
-    override val playlistRepository: PlaylistRepository<Unit>
-) : DependsOnVideoRepository<Unit>,
-    DependsOnPlaylistRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}
-
-class TestImportRemoteDS(override val videoInfoRepository: VideoInfoRepository<Unit>) :
-    DependsOnVideoInfoRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/PlaylistUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/PlaylistUseCaseTest.kt
@@ -43,8 +43,8 @@ class PlaylistUseCaseTest :
                     thumbnail = Playlist.Thumbnail.Video(1L),
                     videos = listOf(1L)
                 )
-                fakeVideoRepo.seed(video)
-                fakePlaylistRepo.seed(playlist)
+                fakeVideoRepo.resetWith(video)
+                fakePlaylistRepo.resetWith(playlist)
 
                 useCase.validateAndUpdateThumbnails()
 
@@ -57,7 +57,7 @@ class PlaylistUseCaseTest :
                     thumbnail = Playlist.Thumbnail.Video(99L),
                     videos = listOf(99L)
                 )
-                fakePlaylistRepo.seed(playlist)
+                fakePlaylistRepo.resetWith(playlist)
 
                 useCase.validateAndUpdateThumbnails()
 
@@ -80,8 +80,8 @@ class PlaylistUseCaseTest :
                     thumbnail = Playlist.Thumbnail.Video(1L),
                     videos = listOf(1L, 2L)
                 )
-                fakeVideoRepo.seed(failedVideo, goodVideo)
-                fakePlaylistRepo.seed(playlist)
+                fakeVideoRepo.resetWith(failedVideo, goodVideo)
+                fakePlaylistRepo.resetWith(playlist)
 
                 useCase.validateAndUpdateThumbnails()
 
@@ -93,8 +93,8 @@ class PlaylistUseCaseTest :
             test("deletes playlist and removes reference from alarms") {
                 val playlist = Playlist(id = 1L)
                 val alarm = Alarm(id = 10L, playlistIds = listOf(1L, 2L))
-                fakeAlarmRepo.seed(alarm)
-                fakePlaylistRepo.seed(playlist)
+                fakeAlarmRepo.resetWith(alarm)
+                fakePlaylistRepo.resetWith(playlist)
 
                 useCase.safeDeletePlaylist(playlist)
 
@@ -104,7 +104,7 @@ class PlaylistUseCaseTest :
 
             test("deletes playlist with no alarm references") {
                 val playlist = Playlist(id = 1L)
-                fakePlaylistRepo.seed(playlist)
+                fakePlaylistRepo.resetWith(playlist)
 
                 useCase.safeDeletePlaylist(playlist)
 
@@ -122,9 +122,9 @@ class PlaylistUseCaseTest :
                     videos = listOf(1L, 2L),
                     thumbnail = Playlist.Thumbnail.Video(1L)
                 )
-                fakeVideoRepo.seed(video1)
-                fakeVideoRepo.seed(video2)
-                fakePlaylistRepo.seed(playlist)
+                fakeVideoRepo.resetWith(video1)
+                fakeVideoRepo.resetWith(video2)
+                fakePlaylistRepo.resetWith(playlist)
 
                 useCase.removeVideosFromPlaylist(playlist, listOf(1L))
 
@@ -137,7 +137,7 @@ class PlaylistUseCaseTest :
         context("setPlaylistThumbnail") {
             test("sets thumbnail to specified video") {
                 val playlist = Playlist(id = 1L)
-                fakePlaylistRepo.seed(playlist)
+                fakePlaylistRepo.resetWith(playlist)
 
                 useCase.setPlaylistThumbnail(playlist, Playlist.Thumbnail.Video(5L))
 
@@ -155,7 +155,7 @@ class PlaylistUseCaseTest :
                         Playlist.SyncRule.ALWAYS_ADD
                     )
                 )
-                fakePlaylistRepo.seed(cloudPlaylist)
+                fakePlaylistRepo.resetWith(cloudPlaylist)
 
                 useCase.updateSyncRule(cloudPlaylist, Playlist.SyncRule.DELETE_IF_NOT_EXIST)
 
@@ -166,7 +166,7 @@ class PlaylistUseCaseTest :
 
             test("does nothing if not CloudPlaylist type") {
                 val originalPlaylist = Playlist(id = 1L, type = Playlist.Type.Original)
-                fakePlaylistRepo.seed(originalPlaylist)
+                fakePlaylistRepo.resetWith(originalPlaylist)
                 val originalThumbnail = originalPlaylist.thumbnail
 
                 useCase.updateSyncRule(originalPlaylist, Playlist.SyncRule.ALWAYS_ADD)

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/PlaylistUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/PlaylistUseCaseTest.kt
@@ -1,46 +1,33 @@
 package net.turtton.ytalarm.usecase
 
-import arrow.core.Either
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import net.turtton.ytalarm.kernel.di.DataSource
-import net.turtton.ytalarm.kernel.di.DependsOnAlarmRepository
-import net.turtton.ytalarm.kernel.di.DependsOnDataSource
-import net.turtton.ytalarm.kernel.di.DependsOnPlaylistRepository
-import net.turtton.ytalarm.kernel.di.DependsOnVideoRepository
 import net.turtton.ytalarm.kernel.entity.Alarm
 import net.turtton.ytalarm.kernel.entity.Playlist
 import net.turtton.ytalarm.kernel.entity.Video
-import net.turtton.ytalarm.kernel.port.AlarmSchedulerPort
-import net.turtton.ytalarm.kernel.repository.AlarmRepository
-import net.turtton.ytalarm.kernel.repository.PlaylistRepository
-import net.turtton.ytalarm.kernel.repository.VideoRepository
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import net.turtton.ytalarm.kernel.fake.FakeAlarmRepository
+import net.turtton.ytalarm.kernel.fake.FakePlaylistRepository
+import net.turtton.ytalarm.kernel.fake.FakeVideoRepository
+import net.turtton.ytalarm.usecase.fake.FakeLocalDataSourceContainer
 
 class PlaylistUseCaseTest :
     FunSpec({
-        lateinit var mockPlaylistRepo: PlaylistRepository<Unit>
-        lateinit var mockVideoRepo: VideoRepository<Unit>
-        lateinit var mockAlarmRepo: AlarmRepository<Unit>
-        lateinit var mockScheduler: AlarmSchedulerPort
-        lateinit var useCase: PlaylistUseCase<Unit, TestPlaylistLocalDS>
+        lateinit var fakePlaylistRepo: FakePlaylistRepository
+        lateinit var fakeVideoRepo: FakeVideoRepository
+        lateinit var fakeAlarmRepo: FakeAlarmRepository
+        lateinit var useCase: PlaylistUseCase<Unit, FakeLocalDataSourceContainer>
 
         beforeEach {
-            mockPlaylistRepo = mock()
-            mockVideoRepo = mock()
-            mockAlarmRepo = mock()
-            mockScheduler = mock()
-            whenever(mockScheduler.scheduleNextAlarm(any())).thenReturn(Either.Right(Unit))
-
-            val ds = TestPlaylistLocalDS(mockPlaylistRepo, mockVideoRepo, mockAlarmRepo)
-            useCase = object : PlaylistUseCase<Unit, TestPlaylistLocalDS> {
-                override val localDataSource: TestPlaylistLocalDS = ds
+            fakePlaylistRepo = FakePlaylistRepository()
+            fakeVideoRepo = FakeVideoRepository()
+            fakeAlarmRepo = FakeAlarmRepository()
+            val ds = FakeLocalDataSourceContainer(
+                alarmRepository = fakeAlarmRepo,
+                videoRepository = fakeVideoRepo,
+                playlistRepository = fakePlaylistRepo
+            )
+            useCase = object : PlaylistUseCase<Unit, FakeLocalDataSourceContainer> {
+                override val localDataSource: FakeLocalDataSourceContainer = ds
             }
         }
 
@@ -56,12 +43,12 @@ class PlaylistUseCaseTest :
                     thumbnail = Playlist.Thumbnail.Video(1L),
                     videos = listOf(1L)
                 )
-                whenever(mockPlaylistRepo.getAllSync(Unit)).thenReturn(listOf(playlist))
-                whenever(mockVideoRepo.getFromIdSync(Unit, 1L)).thenReturn(video)
+                fakeVideoRepo.seed(video)
+                fakePlaylistRepo.seed(playlist)
 
                 useCase.validateAndUpdateThumbnails()
 
-                verify(mockPlaylistRepo, never()).update(any(), any())
+                fakePlaylistRepo.currentData.first().thumbnail shouldBe Playlist.Thumbnail.Video(1L)
             }
 
             test("invalid thumbnail (video missing): update to None") {
@@ -70,15 +57,11 @@ class PlaylistUseCaseTest :
                     thumbnail = Playlist.Thumbnail.Video(99L),
                     videos = listOf(99L)
                 )
-                whenever(mockPlaylistRepo.getAllSync(Unit)).thenReturn(listOf(playlist))
-                whenever(mockVideoRepo.getFromIdSync(Unit, 99L)).thenReturn(null)
-                whenever(mockVideoRepo.getFromIdsSync(Unit, emptyList())).thenReturn(emptyList())
+                fakePlaylistRepo.seed(playlist)
 
                 useCase.validateAndUpdateThumbnails()
 
-                val captor = argumentCaptor<Playlist>()
-                verify(mockPlaylistRepo).update(any(), captor.capture())
-                captor.firstValue.thumbnail shouldBe Playlist.Thumbnail.None
+                fakePlaylistRepo.currentData.first().thumbnail shouldBe Playlist.Thumbnail.None
             }
 
             test("thumbnail video not in Information state: update to fallback") {
@@ -97,17 +80,12 @@ class PlaylistUseCaseTest :
                     thumbnail = Playlist.Thumbnail.Video(1L),
                     videos = listOf(1L, 2L)
                 )
-                whenever(mockPlaylistRepo.getAllSync(Unit)).thenReturn(listOf(playlist))
-                whenever(mockVideoRepo.getFromIdSync(Unit, 1L)).thenReturn(failedVideo)
-                whenever(
-                    mockVideoRepo.getFromIdsSync(Unit, listOf(2L))
-                ).thenReturn(listOf(goodVideo))
+                fakeVideoRepo.seed(failedVideo, goodVideo)
+                fakePlaylistRepo.seed(playlist)
 
                 useCase.validateAndUpdateThumbnails()
 
-                val captor = argumentCaptor<Playlist>()
-                verify(mockPlaylistRepo).update(any(), captor.capture())
-                captor.firstValue.thumbnail shouldBe Playlist.Thumbnail.Video(2L)
+                fakePlaylistRepo.currentData.first().thumbnail shouldBe Playlist.Thumbnail.Video(2L)
             }
         }
 
@@ -115,24 +93,23 @@ class PlaylistUseCaseTest :
             test("deletes playlist and removes reference from alarms") {
                 val playlist = Playlist(id = 1L)
                 val alarm = Alarm(id = 10L, playlistIds = listOf(1L, 2L))
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(listOf(alarm))
+                fakeAlarmRepo.seed(alarm)
+                fakePlaylistRepo.seed(playlist)
 
                 useCase.safeDeletePlaylist(playlist)
 
-                verify(mockPlaylistRepo).delete(any(), any())
-                val alarmCaptor = argumentCaptor<Alarm>()
-                verify(mockAlarmRepo).update(any(), alarmCaptor.capture())
-                alarmCaptor.firstValue.playlistIds shouldBe listOf(2L)
+                fakePlaylistRepo.currentData shouldBe emptyList()
+                fakeAlarmRepo.currentData.first().playlistIds shouldBe listOf(2L)
             }
 
             test("deletes playlist with no alarm references") {
                 val playlist = Playlist(id = 1L)
-                whenever(mockAlarmRepo.getAllSync(Unit)).thenReturn(emptyList())
+                fakePlaylistRepo.seed(playlist)
 
                 useCase.safeDeletePlaylist(playlist)
 
-                verify(mockPlaylistRepo).delete(any(), any())
-                verify(mockAlarmRepo, never()).update(any(), any())
+                fakePlaylistRepo.currentData shouldBe emptyList()
+                fakeAlarmRepo.currentData shouldBe emptyList()
             }
         }
 
@@ -145,29 +122,27 @@ class PlaylistUseCaseTest :
                     videos = listOf(1L, 2L),
                     thumbnail = Playlist.Thumbnail.Video(1L)
                 )
-                whenever(mockVideoRepo.getFromIdSync(Unit, 1L)).thenReturn(video1)
-                whenever(mockVideoRepo.getFromIdSync(Unit, 2L)).thenReturn(video2)
-                whenever(mockVideoRepo.getFromIdsSync(Unit, listOf(2L))).thenReturn(listOf(video2))
+                fakeVideoRepo.seed(video1)
+                fakeVideoRepo.seed(video2)
+                fakePlaylistRepo.seed(playlist)
 
                 useCase.removeVideosFromPlaylist(playlist, listOf(1L))
 
-                val captor = argumentCaptor<Playlist>()
-                verify(mockPlaylistRepo).update(any(), captor.capture())
-                captor.firstValue.videos shouldBe listOf(2L)
-                // サムネイルが削除された動画なので更新される
-                captor.firstValue.thumbnail shouldBe Playlist.Thumbnail.Video(2L)
+                val updatedPlaylist = fakePlaylistRepo.currentData.first()
+                updatedPlaylist.videos shouldBe listOf(2L)
+                updatedPlaylist.thumbnail shouldBe Playlist.Thumbnail.Video(2L)
             }
         }
 
         context("setPlaylistThumbnail") {
             test("sets thumbnail to specified video") {
                 val playlist = Playlist(id = 1L)
+                fakePlaylistRepo.seed(playlist)
 
                 useCase.setPlaylistThumbnail(playlist, Playlist.Thumbnail.Video(5L))
 
-                val captor = argumentCaptor<Playlist>()
-                verify(mockPlaylistRepo).update(any(), captor.capture())
-                captor.firstValue.thumbnail shouldBe Playlist.Thumbnail.Video(5L)
+                val updatedPlaylist = fakePlaylistRepo.currentData.first()
+                updatedPlaylist.thumbnail shouldBe Playlist.Thumbnail.Video(5L)
             }
         }
 
@@ -180,35 +155,24 @@ class PlaylistUseCaseTest :
                         Playlist.SyncRule.ALWAYS_ADD
                     )
                 )
+                fakePlaylistRepo.seed(cloudPlaylist)
 
                 useCase.updateSyncRule(cloudPlaylist, Playlist.SyncRule.DELETE_IF_NOT_EXIST)
 
-                val captor = argumentCaptor<Playlist>()
-                verify(mockPlaylistRepo).update(any(), captor.capture())
-                val updatedType = captor.firstValue.type as Playlist.Type.CloudPlaylist
+                val updatedPlaylist = fakePlaylistRepo.currentData.first()
+                val updatedType = updatedPlaylist.type as Playlist.Type.CloudPlaylist
                 updatedType.syncRule shouldBe Playlist.SyncRule.DELETE_IF_NOT_EXIST
             }
 
             test("does nothing if not CloudPlaylist type") {
                 val originalPlaylist = Playlist(id = 1L, type = Playlist.Type.Original)
+                fakePlaylistRepo.seed(originalPlaylist)
+                val originalThumbnail = originalPlaylist.thumbnail
 
                 useCase.updateSyncRule(originalPlaylist, Playlist.SyncRule.ALWAYS_ADD)
 
-                verify(mockPlaylistRepo, never()).update(any(), any())
+                fakePlaylistRepo.currentData.first().type shouldBe Playlist.Type.Original
+                fakePlaylistRepo.currentData.first().thumbnail shouldBe originalThumbnail
             }
         }
     })
-
-// テスト用のLocalDataSource実装
-class TestPlaylistLocalDS(
-    override val playlistRepository: PlaylistRepository<Unit>,
-    override val videoRepository: VideoRepository<Unit>,
-    override val alarmRepository: AlarmRepository<Unit>
-) : DependsOnPlaylistRepository<Unit>,
-    DependsOnVideoRepository<Unit>,
-    DependsOnAlarmRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/VideoUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/VideoUseCaseTest.kt
@@ -4,40 +4,45 @@ import arrow.core.Either
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import net.turtton.ytalarm.kernel.di.DataSource
-import net.turtton.ytalarm.kernel.di.DependsOnDataSource
-import net.turtton.ytalarm.kernel.di.DependsOnVideoInfoRepository
-import net.turtton.ytalarm.kernel.di.DependsOnVideoRepository
 import net.turtton.ytalarm.kernel.dto.VideoInformation
 import net.turtton.ytalarm.kernel.entity.Alarm
 import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.kernel.error.VideoInfoError
-import net.turtton.ytalarm.kernel.repository.VideoInfoRepository
-import net.turtton.ytalarm.kernel.repository.VideoRepository
-import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import net.turtton.ytalarm.kernel.fake.FakeVideoInfoRepository
+import net.turtton.ytalarm.kernel.fake.FakeVideoRepository
+import net.turtton.ytalarm.usecase.fake.FakeLocalDataSourceContainer
+import net.turtton.ytalarm.usecase.fake.FakeRemoteDataSourceContainer
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 
 class VideoUseCaseTest :
     FunSpec({
-        lateinit var mockVideoRepo: VideoRepository<Unit>
-        lateinit var mockVideoInfoRepo: VideoInfoRepository<Unit>
-        lateinit var useCase: VideoUseCase<Unit, Unit, TestVideoLocalDS, TestVideoRemoteDS>
+        lateinit var fakeVideoRepo: FakeVideoRepository
+        lateinit var fakeVideoInfoRepo: FakeVideoInfoRepository
+        lateinit var useCase: VideoUseCase<
+            Unit,
+            Unit,
+            FakeLocalDataSourceContainer,
+            FakeRemoteDataSourceContainer
+            >
 
         beforeEach {
-            mockVideoRepo = mock()
-            mockVideoInfoRepo = mock()
-
-            val localDs = TestVideoLocalDS(mockVideoRepo)
-            val remoteDs = TestVideoRemoteDS(mockVideoInfoRepo)
-            useCase = object : VideoUseCase<Unit, Unit, TestVideoLocalDS, TestVideoRemoteDS> {
-                override val localDataSource: TestVideoLocalDS = localDs
-                override val remoteDataSource: TestVideoRemoteDS = remoteDs
+            fakeVideoRepo = FakeVideoRepository()
+            fakeVideoInfoRepo = FakeVideoInfoRepository()
+            val localDs = FakeLocalDataSourceContainer(
+                videoRepository = fakeVideoRepo
+            )
+            val remoteDs = FakeRemoteDataSourceContainer(
+                videoInfoRepository = fakeVideoInfoRepo
+            )
+            useCase = object : VideoUseCase<
+                Unit,
+                Unit,
+                FakeLocalDataSourceContainer,
+                FakeRemoteDataSourceContainer
+                > {
+                override val localDataSource: FakeLocalDataSourceContainer = localDs
+                override val remoteDataSource: FakeRemoteDataSourceContainer = remoteDs
             }
         }
 
@@ -59,17 +64,14 @@ class VideoUseCaseTest :
                         videoUrl = "http://example.com/video.mp4"
                     )
                 )
-                whenever(
-                    mockVideoInfoRepo.fetchVideoInfo(Unit, "http://example.com/video")
-                ).thenReturn(Either.Right(fetchedInfo))
+                fakeVideoRepo.seed(failedVideo)
+                fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
+                    Either.Right(fetchedInfo)
 
                 val result = useCase.reimportVideo(failedVideo)
 
                 result shouldBe ReimportResult.Success
-                val captor = argumentCaptor<Video>()
-                verify(mockVideoRepo).update(any(), captor.capture())
-                captor.firstValue.id shouldBe 1L
-                captor.firstValue.videoId shouldBe "newId"
+                fakeVideoRepo.currentData.first { it.id == 1L }.videoId shouldBe "newId"
             }
 
             test("reimport with no url: returns NoUrl error") {
@@ -78,11 +80,13 @@ class VideoUseCaseTest :
                     videoId = "vid1",
                     state = Video.State.Importing
                 )
+                fakeVideoRepo.seed(importingVideo)
 
                 val result = useCase.reimportVideo(importingVideo)
 
                 result shouldBe ReimportResult.Error.NoUrl
-                verify(mockVideoRepo, never()).update(any(), any())
+                fakeVideoRepo.currentData.first { it.id == 1L }.state shouldBe
+                    Video.State.Importing
             }
 
             test("reimport network error: returns Network error") {
@@ -91,16 +95,15 @@ class VideoUseCaseTest :
                     videoId = "vid1",
                     state = Video.State.Failed("http://example.com/video")
                 )
-                whenever(
-                    mockVideoInfoRepo.fetchVideoInfo(Unit, "http://example.com/video")
-                ).thenReturn(
+                fakeVideoRepo.seed(failedVideo)
+                fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
                     Either.Left(VideoInfoError.NetworkError(RuntimeException("network error")))
-                )
 
                 val result = useCase.reimportVideo(failedVideo)
 
                 result shouldBe ReimportResult.Error.Network
-                verify(mockVideoRepo, never()).update(any(), any())
+                fakeVideoRepo.currentData.first { it.id == 1L }.state shouldBe
+                    Video.State.Failed("http://example.com/video")
             }
         }
 
@@ -122,9 +125,7 @@ class VideoUseCaseTest :
                     videoId = "v3",
                     state = Video.State.Importing
                 )
-                whenever(
-                    mockVideoRepo.getFromIdsSync(Unit, listOf(10L, 11L, 12L))
-                ).thenReturn(listOf(playableVideo, failedVideo, importingVideo))
+                fakeVideoRepo.seed(playableVideo, failedVideo, importingVideo)
 
                 val result = useCase.getPlayableVideosForAlarm(
                     alarm,
@@ -143,7 +144,6 @@ class VideoUseCaseTest :
                     id = 1L,
                     videoId = "old",
                     state = Video.State.Importing,
-                    // 作成日時を古くするために creationDate を手動で設定
                     creationDate = Clock.System.now() - 2.hours
                 )
                 val newImporting = Video(
@@ -152,33 +152,17 @@ class VideoUseCaseTest :
                     state = Video.State.Importing,
                     creationDate = Clock.System.now()
                 )
-                whenever(mockVideoRepo.getFromIdsSync(any(), any())).thenReturn(
-                    listOf(oldImporting, newImporting)
+                fakeVideoRepo.seed(oldImporting, newImporting)
+
+                useCase.collectGarbageVideos(
+                    listOf(oldImporting.id, newImporting.id),
+                    threshold
                 )
 
-                useCase.collectGarbageVideos(listOf(oldImporting.id, newImporting.id), threshold)
-
-                val captor = argumentCaptor<Video>()
-                verify(mockVideoRepo).update(any(), captor.capture())
-                captor.firstValue.id shouldBe 1L
-                captor.firstValue.state shouldBe Video.State.Failed("")
+                fakeVideoRepo.currentData.first { it.id == 1L }.state shouldBe
+                    Video.State.Failed("")
+                fakeVideoRepo.currentData.first { it.id == 2L }.state shouldBe
+                    Video.State.Importing
             }
         }
     })
-
-// テスト用DataSource実装
-class TestVideoLocalDS(override val videoRepository: VideoRepository<Unit>) :
-    DependsOnVideoRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}
-
-class TestVideoRemoteDS(override val videoInfoRepository: VideoInfoRepository<Unit>) :
-    DependsOnVideoInfoRepository<Unit>,
-    DependsOnDataSource<Unit> {
-    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
-        override fun createExecutor(): Unit = Unit
-    }
-}

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/VideoUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/VideoUseCaseTest.kt
@@ -64,7 +64,7 @@ class VideoUseCaseTest :
                         videoUrl = "http://example.com/video.mp4"
                     )
                 )
-                fakeVideoRepo.seed(failedVideo)
+                fakeVideoRepo.resetWith(failedVideo)
                 fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
                     Either.Right(fetchedInfo)
 
@@ -80,7 +80,7 @@ class VideoUseCaseTest :
                     videoId = "vid1",
                     state = Video.State.Importing
                 )
-                fakeVideoRepo.seed(importingVideo)
+                fakeVideoRepo.resetWith(importingVideo)
 
                 val result = useCase.reimportVideo(importingVideo)
 
@@ -95,7 +95,7 @@ class VideoUseCaseTest :
                     videoId = "vid1",
                     state = Video.State.Failed("http://example.com/video")
                 )
-                fakeVideoRepo.seed(failedVideo)
+                fakeVideoRepo.resetWith(failedVideo)
                 fakeVideoInfoRepo.videoInfoResponses["http://example.com/video"] =
                     Either.Left(VideoInfoError.NetworkError(RuntimeException("network error")))
 
@@ -125,7 +125,7 @@ class VideoUseCaseTest :
                     videoId = "v3",
                     state = Video.State.Importing
                 )
-                fakeVideoRepo.seed(playableVideo, failedVideo, importingVideo)
+                fakeVideoRepo.resetWith(playableVideo, failedVideo, importingVideo)
 
                 val result = useCase.getPlayableVideosForAlarm(
                     alarm,
@@ -152,7 +152,7 @@ class VideoUseCaseTest :
                     state = Video.State.Importing,
                     creationDate = Clock.System.now()
                 )
-                fakeVideoRepo.seed(oldImporting, newImporting)
+                fakeVideoRepo.resetWith(oldImporting, newImporting)
 
                 useCase.collectGarbageVideos(
                     listOf(oldImporting.id, newImporting.id),

--- a/usecase/src/testFixtures/kotlin/net/turtton/ytalarm/usecase/fake/FakeLocalDataSourceContainer.kt
+++ b/usecase/src/testFixtures/kotlin/net/turtton/ytalarm/usecase/fake/FakeLocalDataSourceContainer.kt
@@ -1,0 +1,19 @@
+package net.turtton.ytalarm.usecase.fake
+
+import net.turtton.ytalarm.kernel.di.DataSource
+import net.turtton.ytalarm.kernel.fake.FakeAlarmRepository
+import net.turtton.ytalarm.kernel.fake.FakePlaylistRepository
+import net.turtton.ytalarm.kernel.fake.FakeVideoRepository
+import net.turtton.ytalarm.kernel.repository.AlarmRepository
+import net.turtton.ytalarm.kernel.repository.PlaylistRepository
+import net.turtton.ytalarm.kernel.repository.VideoRepository
+import net.turtton.ytalarm.usecase.LocalDataSourceContainer
+
+class FakeLocalDataSourceContainer(
+    override val alarmRepository: AlarmRepository<Unit> = FakeAlarmRepository(),
+    override val videoRepository: VideoRepository<Unit> = FakeVideoRepository(),
+    override val playlistRepository: PlaylistRepository<Unit> = FakePlaylistRepository(),
+    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
+        override fun createExecutor() = Unit
+    }
+) : LocalDataSourceContainer<Unit>

--- a/usecase/src/testFixtures/kotlin/net/turtton/ytalarm/usecase/fake/FakeRemoteDataSourceContainer.kt
+++ b/usecase/src/testFixtures/kotlin/net/turtton/ytalarm/usecase/fake/FakeRemoteDataSourceContainer.kt
@@ -1,0 +1,17 @@
+package net.turtton.ytalarm.usecase.fake
+
+import net.turtton.ytalarm.kernel.di.DataSource
+import net.turtton.ytalarm.kernel.fake.FakeVideoDownloadRepository
+import net.turtton.ytalarm.kernel.fake.FakeVideoInfoRepository
+import net.turtton.ytalarm.kernel.repository.VideoDownloadRepository
+import net.turtton.ytalarm.kernel.repository.VideoInfoRepository
+import net.turtton.ytalarm.usecase.RemoteDataSourceContainer
+
+class FakeRemoteDataSourceContainer(
+    override val videoInfoRepository: VideoInfoRepository<Unit> = FakeVideoInfoRepository(),
+    override val videoDownloadRepository: VideoDownloadRepository<Unit> =
+        FakeVideoDownloadRepository(),
+    override val dataSource: DataSource<Unit> = object : DataSource<Unit> {
+        override fun createExecutor() = Unit
+    }
+) : RemoteDataSourceContainer<Unit>


### PR DESCRIPTION
# Type

- ~~Bug fix(バグ修正)~~
- ~~New feature(新機能)~~
- Improvement(機能/コード改善)
- ~~Document changes(翻訳などのドキュメント関係の変更)~~
- ~~Other(その他)~~

# Description

usecaseモジュールのテストをMockitoベースからFakeオブジェクトベースに移行しました。

## 主な変更点

### Fakeオブジェクト追加 (`kernel/src/testFixtures/`)
- `java-test-fixtures`プラグインを導入し、モジュール間で再利用可能なFakeを提供
- `FakeAlarmRepository`, `FakeVideoRepository`, `FakePlaylistRepository` — インメモリ実装、`resetWith()`でテストデータ初期化、`updateHistory`で更新追跡
- `FakeVideoInfoRepository`, `FakeVideoDownloadRepository` — リモート操作のFake
- `FakeAlarmSchedulerPort`, `FakeFileStoragePort` — プラットフォームポートのFake
- 全Fakeリポジトリで`AtomicLong`によるスレッドセーフなID採番

### UseCaseテスト用コンテナ (`usecase/src/testFixtures/`)
- `FakeLocalDataSourceContainer`, `FakeRemoteDataSourceContainer` — テスト用DIコンテナ

### テスト移行 (`usecase/src/test/`)
- `AlarmUseCaseTest`, `PlaylistUseCaseTest`, `VideoUseCaseTest`, `ImportUseCaseTest`, `DownloadUseCaseTest` — 全49テストをFakeベースに移行
- Mockito依存を完全削除

## メリット
- テスト実行速度の向上（Mockitoのリフレクションオーバーヘッド排除）
- テストの可読性向上（明示的な状態管理）
- CI環境での安定性向上
- 将来のapp/workerテストでFakeを再利用可能

# Related Issues

N/A

# Before finish

- [x] I read the [Contributing guide](https://github.com/turtton/YtAlarm/blob/HEAD/.github/CONTRIBUTING.md).
- [x] Run Gradle tasks `formatKotlin` and `check` and make sure no error message is displayed.
- [x] Removed unnecessary commented out code and debug print code.