### PR TITLE
fix(import): use correct playlist title and prevent duplicate playlist creation

### DIFF
--- a/app/src/main/kotlin/net/turtton/ytalarm/navigation/YtAlarmNavGraph.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/navigation/YtAlarmNavGraph.kt
@@ -2,20 +2,10 @@
 
 package net.turtton.ytalarm.navigation
 
-import android.util.Log
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -23,17 +13,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import net.turtton.ytalarm.R
-import net.turtton.ytalarm.YtApplication
-import net.turtton.ytalarm.YtApplication.Companion.dataContainerProvider
-import net.turtton.ytalarm.kernel.entity.Playlist
-import net.turtton.ytalarm.ui.compose.dialogs.DisplayData
-import net.turtton.ytalarm.ui.compose.dialogs.DisplayDataThumbnail
-import net.turtton.ytalarm.ui.compose.dialogs.MultiChoiceVideoDialog
-import net.turtton.ytalarm.ui.compose.dialogs.UrlInputDialog
 import net.turtton.ytalarm.ui.compose.screens.AboutPageScreen
 import net.turtton.ytalarm.ui.compose.screens.AlarmListScreen
 import net.turtton.ytalarm.ui.compose.screens.AllVideosScreen
@@ -41,13 +21,6 @@ import net.turtton.ytalarm.ui.compose.screens.PlaylistScreen
 import net.turtton.ytalarm.ui.compose.screens.SettingsScreen
 import net.turtton.ytalarm.ui.compose.screens.VideoListScreen
 import net.turtton.ytalarm.ui.compose.screens.VideoPlayerScreen
-import net.turtton.ytalarm.util.extensions.createImportingPlaylist
-import net.turtton.ytalarm.util.extensions.updateThumbnail
-import net.turtton.ytalarm.viewmodel.PlaylistViewModel
-import net.turtton.ytalarm.viewmodel.PlaylistViewModelFactory
-import net.turtton.ytalarm.viewmodel.VideoViewModel
-import net.turtton.ytalarm.viewmodel.VideoViewModelFactory
-import net.turtton.ytalarm.worker.VideoInfoDownloadWorker
 
 /**
  * YtAlarmアプリのNavigation Graph
@@ -157,7 +130,6 @@ private fun NavGraphBuilder.playlistScreen(
 /**
  * 動画一覧画面のルート定義
  */
-@Suppress("LongMethod", "CyclomaticComplexMethod")
 private fun NavGraphBuilder.videoListScreen(navController: NavHostController) {
     composable(
         route = YtAlarmDestination.VIDEO_LIST,
@@ -169,31 +141,6 @@ private fun NavGraphBuilder.videoListScreen(navController: NavHostController) {
         )
     ) { backStackEntry ->
         val playlistId = backStackEntry.arguments?.getLong("playlistId") ?: 0L
-        val context = LocalContext.current
-        val scope = rememberCoroutineScope()
-        val snackbarHostState = remember { SnackbarHostState() }
-
-        // Pre-fetch string resources for use in lambdas
-        val msgVideosAdded = stringResource(R.string.message_videos_added)
-        val msgOperationFailed = stringResource(R.string.message_operation_failed)
-
-        // ViewModels
-        val ytApp = context.applicationContext as YtApplication
-        val videoViewModel: VideoViewModel = viewModel(
-            factory = VideoViewModelFactory(
-                ytApp.dataContainerProvider.getUseCaseContainer()
-            )
-        )
-        val playlistViewModel: PlaylistViewModel = viewModel(
-            factory = PlaylistViewModelFactory(
-                ytApp.dataContainerProvider.getUseCaseContainer()
-            )
-        )
-
-        // ダイアログ状態管理
-        var showUrlInputDialog by remember { mutableStateOf(false) }
-        var showMultiChoiceDialog by remember { mutableStateOf(false) }
-        var currentPlaylistIdForDialog by remember { mutableLongStateOf(playlistId) }
 
         VideoListScreen(
             playlistId = playlistId,
@@ -201,138 +148,18 @@ private fun NavGraphBuilder.videoListScreen(navController: NavHostController) {
                 navController.popBackStackSafely()
             },
             onNavigateToVideoPlayer = { videoId ->
-                navController.navigate(YtAlarmDestination.videoPlayer(videoId, isAlarmMode = false))
+                navController.navigate(
+                    YtAlarmDestination.videoPlayer(videoId, isAlarmMode = false)
+                )
             },
-            onShowUrlInputDialog = { plId ->
-                currentPlaylistIdForDialog = plId
-                showUrlInputDialog = true
-            },
-            onShowMultiChoiceDialog = { plId ->
-                currentPlaylistIdForDialog = plId
-                showMultiChoiceDialog = true
+            onNavigateToVideoList = { newPlaylistId ->
+                navController.navigate(YtAlarmDestination.videoList(newPlaylistId)) {
+                    popUpTo(YtAlarmDestination.videoList(0L)) {
+                        inclusive = true
+                    }
+                }
             }
         )
-
-        // UrlInputDialog: URLから動画/プレイリストを追加
-        if (showUrlInputDialog) {
-            UrlInputDialog(
-                onConfirm = { url ->
-                    scope.launch(Dispatchers.IO) {
-                        try {
-                            val targetPlaylistId = if (currentPlaylistIdForDialog != 0L) {
-                                currentPlaylistIdForDialog
-                            } else {
-                                // 新規プレイリスト作成（Importing状態）
-                                val newPlaylist = createImportingPlaylist()
-                                playlistViewModel.insertAsync(newPlaylist).await()
-                            }
-                            // VideoInfoDownloadWorkerを使用してバックグラウンドでインポート
-                            VideoInfoDownloadWorker.registerWorker(
-                                context,
-                                url,
-                                longArrayOf(targetPlaylistId)
-                            )
-                            // 新規プレイリストの場合、新しいIDで画面を再ナビゲート
-                            if (currentPlaylistIdForDialog == 0L) {
-                                withContext(Dispatchers.Main) {
-                                    showUrlInputDialog = false
-                                    navController.navigate(
-                                        YtAlarmDestination.videoList(targetPlaylistId)
-                                    ) {
-                                        popUpTo(YtAlarmDestination.videoList(0L)) {
-                                            inclusive = true
-                                        }
-                                    }
-                                }
-                            } else {
-                                withContext(Dispatchers.Main) {
-                                    showUrlInputDialog = false
-                                }
-                            }
-                        } catch (e: kotlinx.coroutines.CancellationException) {
-                            throw e
-                        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                            Log.e("YtAlarmNavGraph", "Failed to create playlist for URL import", e)
-                            withContext(Dispatchers.Main) {
-                                showUrlInputDialog = false
-                                snackbarHostState.showSnackbar(msgOperationFailed)
-                            }
-                        }
-                    }
-                },
-                onDismiss = { showUrlInputDialog = false }
-            )
-        }
-
-        // MultiChoiceVideoDialog: 既存動画をプレイリストに追加
-        if (showMultiChoiceDialog) {
-            val allVideos by videoViewModel.allVideos.observeAsState(emptyList())
-            val currentPlaylist by playlistViewModel
-                .getFromId(currentPlaylistIdForDialog)
-                .observeAsState()
-            val existingVideoIds = currentPlaylist?.videos?.toSet() ?: emptySet()
-
-            MultiChoiceVideoDialog(
-                displayDataList = allVideos
-                    .filter { it.id !in existingVideoIds }
-                    .map { video ->
-                        DisplayData(
-                            id = video.id,
-                            title = video.title,
-                            thumbnailUrl = video.thumbnailUrl.takeIf {
-                                it.isNotEmpty()
-                            }?.let { DisplayDataThumbnail.Url(it) }
-                        )
-                    },
-                onConfirm = { selectedIds ->
-                    scope.launch(Dispatchers.IO) {
-                        try {
-                            if (currentPlaylistIdForDialog == 0L) {
-                                // 新規プレイリスト作成（既存動画のみなのでOriginal型）
-                                var newPlaylist = Playlist(videos = selectedIds.toList())
-                                newPlaylist.updateThumbnail()?.let { newPlaylist = it }
-                                val newId = playlistViewModel.insertAsync(newPlaylist).await()
-                                // 新しいプレイリストIDで画面を再ナビゲート
-                                withContext(Dispatchers.Main) {
-                                    showMultiChoiceDialog = false
-                                    navController.navigate(YtAlarmDestination.videoList(newId)) {
-                                        popUpTo(YtAlarmDestination.videoList(0L)) {
-                                            inclusive = true
-                                        }
-                                    }
-                                    snackbarHostState.showSnackbar(msgVideosAdded)
-                                }
-                            } else {
-                                // 既存プレイリストに追加
-                                val playlist = playlistViewModel
-                                    .getFromIdAsync(currentPlaylistIdForDialog)
-                                    .await()
-                                if (playlist != null) {
-                                    val updatedVideos = (playlist.videos + selectedIds).distinct()
-                                    playlistViewModel.update(playlist.copy(videos = updatedVideos))
-                                }
-                                withContext(Dispatchers.Main) {
-                                    snackbarHostState.showSnackbar(msgVideosAdded)
-                                }
-                            }
-                        } catch (e: kotlinx.coroutines.CancellationException) {
-                            throw e
-                        } catch (e: android.database.sqlite.SQLiteException) {
-                            Log.e("YtAlarmNavGraph", "Database error adding videos to playlist", e)
-                            withContext(Dispatchers.Main) {
-                                snackbarHostState.showSnackbar(msgOperationFailed)
-                            }
-                        } catch (e: IllegalStateException) {
-                            Log.e("YtAlarmNavGraph", "Failed to add videos to playlist", e)
-                            withContext(Dispatchers.Main) {
-                                snackbarHostState.showSnackbar(msgOperationFailed)
-                            }
-                        }
-                    }
-                },
-                onDismiss = { showMultiChoiceDialog = false }
-            )
-        }
     }
 }
 
@@ -344,34 +171,14 @@ private fun NavGraphBuilder.allVideosScreen(
     onOpenDrawer: () -> Unit
 ) {
     composable(route = YtAlarmDestination.ALL_VIDEOS) {
-        val context = LocalContext.current
-        var showUrlInputDialog by remember { mutableStateOf(false) }
-
         AllVideosScreen(
             onOpenDrawer = onOpenDrawer,
             onNavigateToVideoPlayer = { videoId ->
-                navController.navigate(YtAlarmDestination.videoPlayer(videoId, isAlarmMode = false))
-            },
-            onShowUrlInputDialog = {
-                showUrlInputDialog = true
+                navController.navigate(
+                    YtAlarmDestination.videoPlayer(videoId, isAlarmMode = false)
+                )
             }
         )
-
-        // UrlInputDialog: URLから動画を追加
-        if (showUrlInputDialog) {
-            UrlInputDialog(
-                onConfirm = { url ->
-                    // 全動画モードでは特定のプレイリストに追加しない
-                    VideoInfoDownloadWorker.registerWorker(
-                        context,
-                        url,
-                        longArrayOf()
-                    )
-                    showUrlInputDialog = false
-                },
-                onDismiss = { showUrlInputDialog = false }
-            )
-        }
     }
 }
 

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AlarmListScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AlarmListScreen.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -206,17 +207,21 @@ fun AlarmListScreenContent(
             text = {
                 Column {
                     sortOptions.forEachIndexed { index, option ->
-                        RadioButton(
-                            selected = orderRule.ordinal == index,
-                            onClick = {
-                                onSortRuleChange(AlarmOrder.entries[index])
-                                showSortDialog = false
-                            }
-                        )
-                        Text(
-                            text = option,
-                            modifier = Modifier.padding(start = 8.dp)
-                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = orderRule.ordinal == index,
+                                onClick = {
+                                    onSortRuleChange(AlarmOrder.entries[index])
+                                    showSortDialog = false
+                                }
+                            )
+                            Text(
+                                text = option,
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
                     }
                 }
             },

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AllVideosScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AllVideosScreen.kt
@@ -19,12 +19,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.turtton.ytalarm.R
 import net.turtton.ytalarm.YtApplication
 import net.turtton.ytalarm.YtApplication.Companion.dataContainerProvider
 import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.ui.compose.dialogs.DeleteVideoDialog
+import net.turtton.ytalarm.ui.compose.dialogs.UrlInputDialog
 import net.turtton.ytalarm.ui.compose.dialogs.VideoReimportDialog
 import net.turtton.ytalarm.ui.model.toUiModel
 import net.turtton.ytalarm.util.extensions.findActivity
@@ -36,6 +39,7 @@ import net.turtton.ytalarm.viewmodel.ReimportResult
 import net.turtton.ytalarm.viewmodel.VideoViewModel
 import net.turtton.ytalarm.viewmodel.VideoViewModelFactory
 import net.turtton.ytalarm.worker.VideoFileDownloadWorker
+import net.turtton.ytalarm.worker.VideoInfoDownloadWorker
 
 /**
  * 全動画一覧画面（Compose版）
@@ -48,7 +52,6 @@ import net.turtton.ytalarm.worker.VideoFileDownloadWorker
 fun AllVideosScreen(
     onOpenDrawer: () -> Unit,
     onNavigateToVideoPlayer: (String) -> Unit,
-    onShowUrlInputDialog: () -> Unit,
     modifier: Modifier = Modifier,
     videoViewModel: VideoViewModel = viewModel(
         factory = VideoViewModelFactory(
@@ -67,11 +70,13 @@ fun AllVideosScreen(
     val msgReimportStarted = stringResource(R.string.message_reimport_started)
     val msgReimportErrorParse = stringResource(R.string.message_reimport_error_parse)
     val msgReimportErrorNetwork = stringResource(R.string.message_reimport_error_network)
+    val msgDeleteFailed = stringResource(R.string.message_operation_failed)
 
     val selectedItems = remember { mutableStateListOf<Long>() }
     val expandedMenus = remember { mutableStateMapOf<Long, Boolean>() }
     var videoToDeleteId by remember { mutableStateOf<Long?>(null) }
     var videoToReimportId by remember { mutableStateOf<Long?>(null) }
+    var showUrlInputDialog by remember { mutableStateOf(false) }
 
     val activity = context.findActivity() ?: return
     val preferences = activity.privatePreferences
@@ -145,7 +150,7 @@ fun AllVideosScreen(
             onSyncRuleChange = { /* Not applicable for all videos mode */ },
             onFabExpandToggle = { /* Not used in all videos mode */ },
             onFabMainClick = { /* Not used in all videos mode */ },
-            onFabUrlClick = onShowUrlInputDialog,
+            onFabUrlClick = { showUrlInputDialog = true },
             onFabMultiChoiceClick = { /* Not applicable for all videos mode */ },
             modifier = Modifier.fillMaxSize()
         )
@@ -166,8 +171,15 @@ fun AllVideosScreen(
         DeleteVideoDialog(
             videoTitle = video.title,
             onConfirm = {
-                videoViewModel.delete(video)
-                videoToDeleteId = null
+                scope.launch(Dispatchers.IO) {
+                    val result = videoViewModel.delete(video)
+                    withContext(Dispatchers.Main) {
+                        videoToDeleteId = null
+                        if (result.isFailure) {
+                            snackbarHostState.showSnackbar(msgDeleteFailed)
+                        }
+                    }
+                }
             },
             onDismiss = { videoToDeleteId = null }
         )
@@ -200,6 +212,20 @@ fun AllVideosScreen(
                 }
             },
             onDismiss = { videoToReimportId = null }
+        )
+    }
+
+    if (showUrlInputDialog) {
+        UrlInputDialog(
+            onConfirm = { url ->
+                VideoInfoDownloadWorker.registerWorker(
+                    context,
+                    url,
+                    longArrayOf()
+                )
+                showUrlInputDialog = false
+            },
+            onDismiss = { showUrlInputDialog = false }
         )
     }
 }

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AllVideosScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AllVideosScreen.kt
@@ -3,7 +3,6 @@ package net.turtton.ytalarm.ui.compose.screens
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -14,7 +13,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -152,13 +150,8 @@ fun AllVideosScreen(
             onFabMainClick = { /* Not used in all videos mode */ },
             onFabUrlClick = { showUrlInputDialog = true },
             onFabMultiChoiceClick = { /* Not applicable for all videos mode */ },
-            modifier = Modifier.fillMaxSize()
-        )
-
-        // Snackbar用のホスト
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter)
+            modifier = Modifier.fillMaxSize(),
+            snackbarHostState = snackbarHostState
         )
     }
 

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/PlaylistScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/PlaylistScreen.kt
@@ -2,6 +2,8 @@ package net.turtton.ytalarm.ui.compose.screens
 
 import android.util.Log
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -19,6 +21,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -53,7 +56,6 @@ import net.turtton.ytalarm.R
 import net.turtton.ytalarm.YtApplication
 import net.turtton.ytalarm.YtApplication.Companion.dataContainerProvider
 import net.turtton.ytalarm.kernel.entity.Playlist
-import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.ui.compose.components.PlaylistItem
 import net.turtton.ytalarm.ui.compose.components.PlaylistItemDropdownMenu
 import net.turtton.ytalarm.ui.compose.dialogs.RenamePlaylistDialog
@@ -229,18 +231,18 @@ fun PlaylistScreenContent(
             onDismissRequest = { showSortDialog = false },
             title = { Text(stringResource(R.string.menu_playlist_option_sortrule)) },
             text = {
-                androidx.compose.foundation.layout.Column {
+                Column {
                     sortOptions.forEachIndexed { index, option ->
-                        androidx.compose.material3.RadioButton(
-                            selected = orderRule.ordinal == index,
-                            onClick = {
-                                onSortRuleChange(PlaylistOrder.entries[index])
-                                showSortDialog = false
-                            }
-                        )
-                        androidx.compose.foundation.layout.Row(
+                        Row(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
+                            RadioButton(
+                                selected = orderRule.ordinal == index,
+                                onClick = {
+                                    onSortRuleChange(PlaylistOrder.entries[index])
+                                    showSortDialog = false
+                                }
+                            )
                             Text(
                                 text = option,
                                 modifier = Modifier.padding(start = 8.dp)
@@ -328,6 +330,7 @@ fun PlaylistScreen(
     val msgPlaylistRenamed = stringResource(R.string.message_playlist_renamed)
     val msgPlaylistDeleted = stringResource(R.string.message_playlist_deleted)
     val msgDeleteFailed = stringResource(R.string.error_delete_playlist_failed)
+    val msgOperationFailed = stringResource(R.string.message_operation_failed)
 
     val playlists by playlistViewModel.allPlaylists.observeAsState(emptyList())
     val alarms by alarmViewModel.allAlarms.observeAsState(emptyList())
@@ -347,40 +350,6 @@ fun PlaylistScreen(
     val preferences = activity.privatePreferences
     val orderRule = preferences.playlistOrderRule
     val orderUp = preferences.playlistOrderUp
-
-    // ガベージコレクション（Importing状態で終了したプレイリストを削除）
-    LaunchedEffect(playlists) {
-        scope.launch(Dispatchers.IO) {
-            try {
-                // 最新のplaylistsを取得
-                val currentPlaylists = playlistViewModel.allPlaylistsAsync.await()
-                val importingPlaylists = currentPlaylists.filter {
-                    it.type is Playlist.Type.Importing
-                }
-                val videoIds = importingPlaylists.mapNotNull { it.videos.firstOrNull() }.distinct()
-                val videoMap = if (videoIds.isEmpty()) {
-                    emptyMap()
-                } else {
-                    videoViewModel.getFromIdsAsync(videoIds).await()
-                        .associateBy { it.id }
-                }
-                val garbage = importingPlaylists.filter { playlist ->
-                    val videoId = playlist.videos.firstOrNull() ?: return@filter false
-                    videoMap[videoId]?.state is Video.State.Failed
-                }
-                if (garbage.isNotEmpty()) {
-                    playlistViewModel.delete(garbage)
-                }
-            } catch (e: kotlinx.coroutines.CancellationException) {
-                // キャンセル例外は再スロー
-                throw e
-            } catch (e: android.database.sqlite.SQLiteException) {
-                android.util.Log.e("PlaylistScreen", "Database error during garbage collection", e)
-            } catch (e: IllegalStateException) {
-                android.util.Log.e("PlaylistScreen", "Garbage collection failed", e)
-            }
-        }
-    }
 
     // ソート処理
     val sortedPlaylists = remember(playlists, orderRule, orderUp) {
@@ -483,7 +452,12 @@ fun PlaylistScreen(
                 }
 
                 if (deletable.isNotEmpty()) {
-                    playlistViewModel.delete(deletable)
+                    val deleteResult = playlistViewModel.delete(deletable)
+                    if (deleteResult.isFailure) {
+                        withContext(Dispatchers.Main) {
+                            snackbarHostState.showSnackbar(msgDeleteFailed)
+                        }
+                    }
                 }
 
                 if (detectUsage) {
@@ -520,10 +494,16 @@ fun PlaylistScreen(
         RenamePlaylistDialog(
             currentTitle = playlist.title,
             onConfirm = { newName ->
-                playlistViewModel.update(playlist.copy(title = newName))
-                playlistToRenameId = null
-                scope.launch {
-                    snackbarHostState.showSnackbar(msgPlaylistRenamed)
+                scope.launch(Dispatchers.IO) {
+                    val result = playlistViewModel.update(playlist.copy(title = newName))
+                    withContext(Dispatchers.Main) {
+                        playlistToRenameId = null
+                        if (result.isSuccess) {
+                            snackbarHostState.showSnackbar(msgPlaylistRenamed)
+                        } else {
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                    }
                 }
             },
             onDismiss = { playlistToRenameId = null }
@@ -566,12 +546,16 @@ fun PlaylistScreen(
                                 }
 
                                 ensureActive()
-                                playlistViewModel.delete(playlist)
+                                val deleteResult = playlistViewModel.delete(playlist)
                                 ensureActive()
 
                                 withContext(Dispatchers.Main) {
                                     playlistToDeleteId = null
-                                    snackbarHostState.showSnackbar(msgPlaylistDeleted)
+                                    if (deleteResult.isSuccess) {
+                                        snackbarHostState.showSnackbar(msgPlaylistDeleted)
+                                    } else {
+                                        snackbarHostState.showSnackbar(msgDeleteFailed)
+                                    }
                                 }
                             } catch (e: CancellationException) {
                                 throw e

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
@@ -1,5 +1,6 @@
 package net.turtton.ytalarm.ui.compose.screens
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
@@ -7,6 +8,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -28,6 +30,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.SnackbarHost
@@ -73,15 +76,21 @@ import net.turtton.ytalarm.kernel.entity.Playlist
 import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.ui.compose.components.VideoItem
 import net.turtton.ytalarm.ui.compose.components.VideoItemDropdownMenu
+import net.turtton.ytalarm.ui.compose.dialogs.DisplayData
+import net.turtton.ytalarm.ui.compose.dialogs.DisplayDataThumbnail
+import net.turtton.ytalarm.ui.compose.dialogs.MultiChoiceVideoDialog
 import net.turtton.ytalarm.ui.compose.dialogs.RemoveOrDeleteVideoDialog
+import net.turtton.ytalarm.ui.compose.dialogs.UrlInputDialog
 import net.turtton.ytalarm.ui.compose.dialogs.VideoReimportDialog
 import net.turtton.ytalarm.ui.compose.theme.AppTheme
 import net.turtton.ytalarm.ui.compose.theme.Dimensions
 import net.turtton.ytalarm.ui.model.VideoUiModel
 import net.turtton.ytalarm.ui.model.toUiModel
+import net.turtton.ytalarm.util.extensions.createImportingPlaylist
 import net.turtton.ytalarm.util.extensions.findActivity
 import net.turtton.ytalarm.util.extensions.privatePreferences
 import net.turtton.ytalarm.util.extensions.sorted
+import net.turtton.ytalarm.util.extensions.updateThumbnail
 import net.turtton.ytalarm.util.extensions.videoOrderRule
 import net.turtton.ytalarm.util.extensions.videoOrderUp
 import net.turtton.ytalarm.util.order.VideoOrder
@@ -391,17 +400,21 @@ fun VideoListScreenContent(
             text = {
                 Column {
                     sortOptions.forEachIndexed { index, option ->
-                        androidx.compose.material3.RadioButton(
-                            selected = orderRule.ordinal == index,
-                            onClick = {
-                                onSortRuleChange(VideoOrder.entries[index])
-                                showSortDialog = false
-                            }
-                        )
-                        Text(
-                            text = option,
-                            modifier = Modifier.padding(start = 8.dp)
-                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = orderRule.ordinal == index,
+                                onClick = {
+                                    onSortRuleChange(VideoOrder.entries[index])
+                                    showSortDialog = false
+                                }
+                            )
+                            Text(
+                                text = option,
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
                     }
                 }
             },
@@ -447,17 +460,21 @@ fun VideoListScreenContent(
             text = {
                 Column {
                     syncRuleOptions.forEachIndexed { index, option ->
-                        androidx.compose.material3.RadioButton(
-                            selected = currentRule?.ordinal == index,
-                            onClick = {
-                                onSyncRuleChange(Playlist.SyncRule.entries[index])
-                                showSyncRuleDialog = false
-                            }
-                        )
-                        Text(
-                            text = option,
-                            modifier = Modifier.padding(start = 8.dp)
-                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = currentRule?.ordinal == index,
+                                onClick = {
+                                    onSyncRuleChange(Playlist.SyncRule.entries[index])
+                                    showSyncRuleDialog = false
+                                }
+                            )
+                            Text(
+                                text = option,
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
                     }
                 }
             },
@@ -488,8 +505,7 @@ fun VideoListScreen(
     playlistId: Long,
     onNavigateBack: () -> Unit,
     onNavigateToVideoPlayer: (String) -> Unit,
-    onShowUrlInputDialog: (Long) -> Unit,
-    onShowMultiChoiceDialog: (Long) -> Unit,
+    onNavigateToVideoList: (Long) -> Unit,
     modifier: Modifier = Modifier,
     videoViewModel: VideoViewModel = viewModel(
         factory = VideoViewModelFactory(
@@ -518,6 +534,8 @@ fun VideoListScreen(
     val msgReimportStarted = stringResource(R.string.message_reimport_started)
     val msgReimportErrorParse = stringResource(R.string.message_reimport_error_parse)
     val msgReimportErrorNetwork = stringResource(R.string.message_reimport_error_network)
+    val msgVideosAdded = stringResource(R.string.message_videos_added)
+    val msgOperationFailed = stringResource(R.string.message_operation_failed)
 
     val currentId by remember { mutableLongStateOf(playlistId) }
     // playlistId == 0の場合は新規プレイリスト作成モード（空のリスト）
@@ -535,6 +553,8 @@ fun VideoListScreen(
     val expandedMenus = remember { mutableStateMapOf<Long, Boolean>() }
     var videoToDeleteId by remember { mutableStateOf<Long?>(null) }
     var videoToReimportId by remember { mutableStateOf<Long?>(null) }
+    var showUrlInputDialog by remember { mutableStateOf(false) }
+    var showMultiChoiceDialog by remember { mutableStateOf(false) }
 
     val activity = context.findActivity() ?: return
     val preferences = activity.privatePreferences
@@ -619,12 +639,18 @@ fun VideoListScreen(
             },
             onSetThumbnail = { videoId ->
                 playlist?.let { pl ->
-                    playlistViewModel.update(
-                        pl.copy(thumbnail = Playlist.Thumbnail.Video(videoId))
-                    )
-                }
-                scope.launch {
-                    snackbarHostState.showSnackbar(msgThumbnailSet)
+                    scope.launch(Dispatchers.IO) {
+                        val result = playlistViewModel.update(
+                            pl.copy(thumbnail = Playlist.Thumbnail.Video(videoId))
+                        )
+                        withContext(Dispatchers.Main) {
+                            if (result.isSuccess) {
+                                snackbarHostState.showSnackbar(msgThumbnailSet)
+                            } else {
+                                snackbarHostState.showSnackbar(msgOperationFailed)
+                            }
+                        }
+                    }
                 }
             },
             onDownload = { videoId ->
@@ -642,10 +668,15 @@ fun VideoListScreen(
                     // 選択された動画をプレイリストから削除
                     val currentPlaylist = playlistViewModel.getFromIdAsync(currentId).await()
                     currentPlaylist?.let { pl ->
-                        playlistViewModel.removeVideosFromPlaylist(
+                        val result = playlistViewModel.removeVideosFromPlaylist(
                             pl,
                             selectedItems.toList()
                         )
+                        if (result.isFailure) {
+                            withContext(Dispatchers.Main) {
+                                snackbarHostState.showSnackbar(msgOperationFailed)
+                            }
+                        }
                     }
 
                     withContext(Dispatchers.Main) {
@@ -665,7 +696,12 @@ fun VideoListScreen(
                     val type = pl?.type as? Playlist.Type.CloudPlaylist
                     if (pl != null && type != null) {
                         val updatedType = type.copy(syncRule = rule)
-                        playlistViewModel.update(pl.copy(type = updatedType))
+                        val result = playlistViewModel.update(pl.copy(type = updatedType))
+                        if (result.isFailure) {
+                            withContext(Dispatchers.Main) {
+                                snackbarHostState.showSnackbar(msgOperationFailed)
+                            }
+                        }
                     }
                 }
             },
@@ -690,11 +726,11 @@ fun VideoListScreen(
             },
             onFabUrlClick = {
                 isFabExpanded = false
-                onShowUrlInputDialog(currentId)
+                showUrlInputDialog = true
             },
             onFabMultiChoiceClick = {
                 isFabExpanded = false
-                onShowMultiChoiceDialog(currentId)
+                showMultiChoiceDialog = true
             },
             modifier = Modifier.fillMaxSize()
         )
@@ -715,22 +751,41 @@ fun VideoListScreen(
         RemoveOrDeleteVideoDialog(
             videoTitle = video.title,
             onRemoveFromPlaylist = {
-                playlist?.let { pl ->
-                    playlistViewModel.removeVideosFromPlaylist(pl, listOf(id))
-                }
-                videoToDeleteId = null
-                scope.launch {
-                    snackbarHostState.showSnackbar(msgVideoRemovedFromPlaylist)
+                scope.launch(Dispatchers.IO) {
+                    val result = playlist?.let { pl ->
+                        playlistViewModel.removeVideosFromPlaylist(pl, listOf(id))
+                    }
+                    withContext(Dispatchers.Main) {
+                        videoToDeleteId = null
+                        if (result?.isFailure == true) {
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        } else {
+                            snackbarHostState.showSnackbar(msgVideoRemovedFromPlaylist)
+                        }
+                    }
                 }
             },
             onDeleteVideo = {
-                playlist?.let { pl ->
-                    playlistViewModel.removeVideosFromPlaylist(pl, listOf(id))
-                }
-                videoViewModel.delete(video)
-                videoToDeleteId = null
-                scope.launch {
-                    snackbarHostState.showSnackbar(msgVideoDeleted)
+                scope.launch(Dispatchers.IO) {
+                    val removeResult = playlist?.let { pl ->
+                        playlistViewModel.removeVideosFromPlaylist(pl, listOf(id))
+                    }
+                    if (removeResult?.isFailure == true) {
+                        withContext(Dispatchers.Main) {
+                            videoToDeleteId = null
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                        return@launch
+                    }
+                    val result = videoViewModel.delete(video)
+                    withContext(Dispatchers.Main) {
+                        videoToDeleteId = null
+                        if (result.isSuccess) {
+                            snackbarHostState.showSnackbar(msgVideoDeleted)
+                        } else {
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                    }
                 }
             },
             onDismiss = { videoToDeleteId = null }
@@ -766,7 +821,120 @@ fun VideoListScreen(
             onDismiss = { videoToReimportId = null }
         )
     }
+
+    if (showUrlInputDialog) {
+        UrlInputDialog(
+            onConfirm = { url ->
+                scope.launch(Dispatchers.IO) {
+                    try {
+                        val targetPlaylistId = if (currentId != 0L) {
+                            currentId
+                        } else {
+                            val newPlaylist = createImportingPlaylist()
+                            playlistViewModel.insertAsync(newPlaylist).await()
+                        }
+                        VideoInfoDownloadWorker.registerWorker(
+                            context,
+                            url,
+                            longArrayOf(targetPlaylistId)
+                        )
+                        withContext(Dispatchers.Main) {
+                            showUrlInputDialog = false
+                            if (currentId == 0L) {
+                                onNavigateToVideoList(targetPlaylistId)
+                            }
+                        }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                        Log.e(TAG, "Failed to create playlist for URL import", e)
+                        withContext(Dispatchers.Main) {
+                            showUrlInputDialog = false
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                    }
+                }
+            },
+            onDismiss = { showUrlInputDialog = false }
+        )
+    }
+
+    if (showMultiChoiceDialog) {
+        val allVideos by videoViewModel.allVideos.observeAsState(emptyList())
+        val existingVideoIds = playlist?.videos?.toSet() ?: emptySet()
+
+        MultiChoiceVideoDialog(
+            displayDataList = allVideos
+                .filter { it.id !in existingVideoIds }
+                .map { video ->
+                    DisplayData(
+                        id = video.id,
+                        title = video.title,
+                        thumbnailUrl = video.thumbnailUrl.takeIf {
+                            it.isNotEmpty()
+                        }?.let { DisplayDataThumbnail.Url(it) }
+                    )
+                },
+            onConfirm = { selectedIds ->
+                scope.launch(Dispatchers.IO) {
+                    try {
+                        if (currentId == 0L) {
+                            var newPlaylist = Playlist(videos = selectedIds.toList())
+                            newPlaylist.updateThumbnail()?.let { newPlaylist = it }
+                            val newId = playlistViewModel.insertAsync(newPlaylist).await()
+                            withContext(Dispatchers.Main) {
+                                showMultiChoiceDialog = false
+                                onNavigateToVideoList(newId)
+                                snackbarHostState.showSnackbar(msgVideosAdded)
+                            }
+                        } else {
+                            val targetPlaylist = playlistViewModel
+                                .getFromIdAsync(currentId)
+                                .await()
+                            if (targetPlaylist != null) {
+                                val updatedVideos =
+                                    (targetPlaylist.videos + selectedIds).distinct()
+                                val updateResult = playlistViewModel.update(
+                                    targetPlaylist.copy(videos = updatedVideos)
+                                )
+                                withContext(Dispatchers.Main) {
+                                    showMultiChoiceDialog = false
+                                    if (updateResult.isSuccess) {
+                                        snackbarHostState.showSnackbar(msgVideosAdded)
+                                    } else {
+                                        snackbarHostState.showSnackbar(msgOperationFailed)
+                                    }
+                                }
+                            } else {
+                                withContext(Dispatchers.Main) {
+                                    showMultiChoiceDialog = false
+                                    snackbarHostState.showSnackbar(msgOperationFailed)
+                                }
+                            }
+                        }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (e: android.database.sqlite.SQLiteException) {
+                        Log.e(TAG, "Database error adding videos to playlist", e)
+                        withContext(Dispatchers.Main) {
+                            showMultiChoiceDialog = false
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                    } catch (e: IllegalStateException) {
+                        Log.e(TAG, "Failed to add videos to playlist", e)
+                        withContext(Dispatchers.Main) {
+                            showMultiChoiceDialog = false
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                    }
+                }
+            },
+            onDismiss = { showMultiChoiceDialog = false }
+        )
+    }
 }
+
+private const val TAG = "VideoListScreen"
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
@@ -42,8 +42,8 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -149,9 +149,9 @@ fun VideoListScreenContent(
     onFabUrlClick: () -> Unit,
     onFabMultiChoiceClick: () -> Unit,
     modifier: Modifier = Modifier,
+    snackbarHostState: SnackbarHostState,
     onOpenDrawer: () -> Unit = {}
 ) {
-    val snackbarHostState = remember { SnackbarHostState() }
     var showSortDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showSyncRuleDialog by remember { mutableStateOf(false) }
@@ -252,34 +252,34 @@ fun VideoListScreenContent(
                     // Sync中の回転アニメーション
                     val syncRotation = remember { Animatable(0f) }
                     val shouldRotate = isSyncMode && isSyncing
-                    // shouldRotateはパラメータ由来のローカル変数のため、snapshotFlowで
-                    // 変更を検知するにはrememberUpdatedStateでState化する必要がある
-                    val currentShouldRotate by rememberUpdatedState(shouldRotate)
 
-                    // LaunchedEffect(Unit)を使用する理由:
-                    // - shouldRotateがfalseになっても即座に停止せず、1周完了してから停止させたい
-                    // - LaunchedEffect(shouldRotate)だと変更時に即キャンセル→再起動され、
-                    //   回転途中から0°へアニメーションして逆回転になってしまう
-                    // - コンポーネント破棄時はCoroutineScopeがキャンセルされるため問題なし
-                    LaunchedEffect(Unit) {
-                        while (true) {
-                            // 回転許可が出るまで待機（snapshotFlowでState変更を監視）
-                            snapshotFlow { currentShouldRotate }.filter { it }.first()
-                            val startTime = System.currentTimeMillis()
-                            syncRotation.animateTo(
-                                targetValue = SYNC_ROTATION_DEGREES,
-                                animationSpec = tween(
-                                    durationMillis = SYNC_ANIMATION_DURATION_MS,
-                                    easing = LinearEasing
+                    if (isSyncMode) {
+                        val currentShouldRotate by rememberUpdatedState(shouldRotate)
+
+                        // LaunchedEffect(Unit)を使用する理由:
+                        // - shouldRotateがfalseになっても即座に停止せず、1周完了してから停止させたい
+                        // - LaunchedEffect(shouldRotate)だと変更時に即キャンセル→再起動され、
+                        //   回転途中から0°へアニメーションして逆回転になってしまう
+                        // - コンポーネント破棄時はCoroutineScopeがキャンセルされるため問題なし
+                        LaunchedEffect(Unit) {
+                            while (true) {
+                                snapshotFlow { currentShouldRotate }.filter { it }.first()
+                                val startTime = System.currentTimeMillis()
+                                syncRotation.animateTo(
+                                    targetValue = SYNC_ROTATION_DEGREES,
+                                    animationSpec = tween(
+                                        durationMillis = SYNC_ANIMATION_DURATION_MS,
+                                        easing = LinearEasing
+                                    )
                                 )
-                            )
-                            // アニメーションOFF端末ではanimateToが即座に完了するため、
-                            // 無限ループが高速回転してCPU負荷が発生する。これを防止する。
-                            val elapsedTime = System.currentTimeMillis() - startTime
-                            if (elapsedTime < ANIMATION_MIN_DURATION_MS) {
-                                delay(ANIMATION_FALLBACK_DELAY_MS)
+                                // アニメーションOFF端末ではanimateToが即座に完了するため、
+                                // 無限ループが高速回転してCPU負荷が発生する。これを防止する。
+                                val elapsedTime = System.currentTimeMillis() - startTime
+                                if (elapsedTime < ANIMATION_MIN_DURATION_MS) {
+                                    delay(ANIMATION_FALLBACK_DELAY_MS)
+                                }
+                                syncRotation.snapTo(0f)
                             }
-                            syncRotation.snapTo(0f)
                         }
                     }
 
@@ -520,6 +520,46 @@ fun VideoListScreen(
         )
     )
 ) {
+    val currentId = playlistId
+    val isNewPlaylistMode = currentId == 0L
+
+    // playlistIdが変わった場合にscreen-local stateをリセットするためkeyブロックで囲む
+    key(playlistId) {
+        VideoListScreenInner(
+            currentId = currentId,
+            isNewPlaylistMode = isNewPlaylistMode,
+            onNavigateBack = onNavigateBack,
+            onNavigateToVideoPlayer = onNavigateToVideoPlayer,
+            onNavigateToVideoList = onNavigateToVideoList,
+            modifier = modifier,
+            videoViewModel = videoViewModel,
+            playlistViewModel = playlistViewModel
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun VideoListScreenInner(
+    currentId: Long,
+    isNewPlaylistMode: Boolean,
+    onNavigateBack: () -> Unit,
+    onNavigateToVideoPlayer: (String) -> Unit,
+    onNavigateToVideoList: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    videoViewModel: VideoViewModel = viewModel(
+        factory = VideoViewModelFactory(
+            (LocalContext.current.applicationContext as YtApplication).dataContainerProvider
+                .getUseCaseContainer()
+        )
+    ),
+    playlistViewModel: PlaylistViewModel = viewModel(
+        factory = PlaylistViewModelFactory(
+            (LocalContext.current.applicationContext as YtApplication).dataContainerProvider
+                .getUseCaseContainer()
+        )
+    )
+) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -537,10 +577,6 @@ fun VideoListScreen(
     val msgVideosAdded = stringResource(R.string.message_videos_added)
     val msgOperationFailed = stringResource(R.string.message_operation_failed)
 
-    val currentId by remember { mutableLongStateOf(playlistId) }
-    // playlistId == 0の場合は新規プレイリスト作成モード（空のリスト）
-    // 全動画表示は AllVideosScreen で処理するため、ここでは扱わない
-    val isNewPlaylistMode = currentId == 0L
     val playlist by if (isNewPlaylistMode) {
         remember { mutableStateOf<Playlist?>(null) }
     } else {
@@ -549,7 +585,6 @@ fun VideoListScreen(
     val selectedItems = remember { mutableStateListOf<Long>() }
     var isFabExpanded by remember { mutableStateOf(false) }
 
-    // メニュー展開状態の管理
     val expandedMenus = remember { mutableStateMapOf<Long, Boolean>() }
     var videoToDeleteId by remember { mutableStateOf<Long?>(null) }
     var videoToReimportId by remember { mutableStateOf<Long?>(null) }
@@ -561,12 +596,9 @@ fun VideoListScreen(
     val orderRule = preferences.videoOrderRule
     val orderUp = preferences.videoOrderUp
 
-    // プレイリストのタイプを取得
     val playlistType = playlist?.type
-    val isOriginalMode = playlistType is Playlist.Type.Original || playlistType == null
     val isSyncMode = playlistType is Playlist.Type.CloudPlaylist
 
-    // 同期Workerの状態を監視
     val syncWorkInfo by WorkManager.getInstance(context)
         .getWorkInfosForUniqueWorkLiveData("SyncWorker_$currentId")
         .observeAsState(emptyList())
@@ -574,173 +606,153 @@ fun VideoListScreen(
         workInfo.state == WorkInfo.State.RUNNING || workInfo.state == WorkInfo.State.ENQUEUED
     }
 
-    // 動画リストを取得
-    // - playlistId=0 (新規プレイリスト): 空のリスト
-    // - playlistId>0 (既存プレイリスト): プレイリストの動画を取得
-    // 全動画表示は AllVideosScreen で処理
     val videos by if (isNewPlaylistMode) {
-        // 新規プレイリスト作成モード: 空のリスト
         remember { mutableStateOf(emptyList<Video>()) }
     } else {
-        // 既存プレイリストの動画を取得
         val videoIds = playlist?.videos ?: emptyList()
         videoViewModel.getFromIds(videoIds).observeAsState(emptyList())
     }
 
-    // ソート処理
     val sortedVideos = remember(videos, orderRule, orderUp) {
         videos.sorted(orderRule, orderUp)
     }
 
-    // ID→Videoマップ（ダイアログ等でVideoオブジェクトが必要な場合に使用）
     val videoMap = remember(videos) { videos.associateBy { it.id } }
 
-    // UiModel変換
     val videoUiModels = remember(sortedVideos) { sortedVideos.map { it.toUiModel() } }
 
-    // タイトルの決定: 新規プレイリストモード、既存プレイリストモード
-    // 全動画モードは AllVideosScreen で処理
     val playlistTitle = if (isNewPlaylistMode) {
         stringResource(R.string.nav_video_list_new)
     } else {
         playlist?.title ?: stringResource(R.string.nav_video_list)
     }
-
-    // VideoListScreenContentを呼び出す
     // isAllVideosMode = false: 全動画モードは AllVideosScreen で処理
-    Box(modifier = modifier.fillMaxSize()) {
-        VideoListScreenContent(
-            playlistTitle = playlistTitle,
-            isNewPlaylist = isNewPlaylistMode,
-            isAllVideosMode = false,
-            videos = videoUiModels,
-            playlistType = playlistType,
-            orderRule = orderRule,
-            orderUp = orderUp,
-            selectedItems = selectedItems.toList(),
-            isFabExpanded = isFabExpanded,
-            isSyncing = isSyncing,
-            expandedMenus = expandedMenus,
-            onItemSelect = { id, isSelected ->
-                if (isSelected) {
-                    selectedItems.add(id)
-                } else {
-                    selectedItems.remove(id)
-                }
-            },
-            onItemClick = { videoId ->
-                onNavigateToVideoPlayer(videoId)
-            },
-            onMenuClick = { videoId ->
-                expandedMenus[videoId] = true
-            },
-            onMenuDismiss = { videoId ->
-                expandedMenus.remove(videoId)
-            },
-            onSetThumbnail = { videoId ->
-                playlist?.let { pl ->
-                    scope.launch(Dispatchers.IO) {
-                        val result = playlistViewModel.update(
-                            pl.copy(thumbnail = Playlist.Thumbnail.Video(videoId))
-                        )
-                        withContext(Dispatchers.Main) {
-                            if (result.isSuccess) {
-                                snackbarHostState.showSnackbar(msgThumbnailSet)
-                            } else {
-                                snackbarHostState.showSnackbar(msgOperationFailed)
-                            }
-                        }
-                    }
-                }
-            },
-            onDownload = { videoId ->
-                VideoFileDownloadWorker.registerWorker(context, videoId)
-            },
-            onReimport = { videoId ->
-                videoToReimportId = videoId
-            },
-            onDeleteSingleVideo = { videoId ->
-                videoToDeleteId = videoId
-            },
-            onNavigateBack = onNavigateBack,
-            onDeleteVideos = {
+    VideoListScreenContent(
+        playlistTitle = playlistTitle,
+        isNewPlaylist = isNewPlaylistMode,
+        isAllVideosMode = false,
+        videos = videoUiModels,
+        playlistType = playlistType,
+        orderRule = orderRule,
+        orderUp = orderUp,
+        selectedItems = selectedItems.toList(),
+        isFabExpanded = isFabExpanded,
+        isSyncing = isSyncing,
+        expandedMenus = expandedMenus,
+        onItemSelect = { id, isSelected ->
+            if (isSelected) {
+                selectedItems.add(id)
+            } else {
+                selectedItems.remove(id)
+            }
+        },
+        onItemClick = { videoId ->
+            onNavigateToVideoPlayer(videoId)
+        },
+        onMenuClick = { videoId ->
+            expandedMenus[videoId] = true
+        },
+        onMenuDismiss = { videoId ->
+            expandedMenus.remove(videoId)
+        },
+        onSetThumbnail = { videoId ->
+            playlist?.let { pl ->
                 scope.launch(Dispatchers.IO) {
-                    // 選択された動画をプレイリストから削除
-                    val currentPlaylist = playlistViewModel.getFromIdAsync(currentId).await()
-                    currentPlaylist?.let { pl ->
-                        val result = playlistViewModel.removeVideosFromPlaylist(
-                            pl,
-                            selectedItems.toList()
-                        )
-                        if (result.isFailure) {
-                            withContext(Dispatchers.Main) {
-                                snackbarHostState.showSnackbar(msgOperationFailed)
-                            }
-                        }
-                    }
-
-                    withContext(Dispatchers.Main) {
-                        selectedItems.clear()
-                    }
-                }
-            },
-            onSortRuleChange = { rule ->
-                preferences.videoOrderRule = rule
-            },
-            onOrderUpToggle = {
-                preferences.videoOrderUp = !orderUp
-            },
-            onSyncRuleChange = { rule ->
-                scope.launch(Dispatchers.IO) {
-                    val pl = playlistViewModel.getFromIdAsync(currentId).await()
-                    val type = pl?.type as? Playlist.Type.CloudPlaylist
-                    if (pl != null && type != null) {
-                        val updatedType = type.copy(syncRule = rule)
-                        val result = playlistViewModel.update(pl.copy(type = updatedType))
-                        if (result.isFailure) {
-                            withContext(Dispatchers.Main) {
-                                snackbarHostState.showSnackbar(msgOperationFailed)
-                            }
-                        }
-                    }
-                }
-            },
-            onFabExpandToggle = {
-                isFabExpanded = !isFabExpanded
-            },
-            onFabMainClick = {
-                // Syncモード: 同期実行
-                val cloudType = playlist?.type as? Playlist.Type.CloudPlaylist
-                if (cloudType != null) {
-                    // Worker登録を先に実行（snackbarは待機するため）
-                    VideoInfoDownloadWorker.registerSyncWorker(
-                        context,
-                        currentId,
-                        cloudType.url
+                    val result = playlistViewModel.update(
+                        pl.copy(thumbnail = Playlist.Thumbnail.Video(videoId))
                     )
-                    // スナックバーは非同期で表示
-                    scope.launch {
-                        snackbarHostState.showSnackbar(msgSyncStarted)
+                    withContext(Dispatchers.Main) {
+                        if (result.isSuccess) {
+                            snackbarHostState.showSnackbar(msgThumbnailSet)
+                        } else {
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
                     }
                 }
-            },
-            onFabUrlClick = {
-                isFabExpanded = false
-                showUrlInputDialog = true
-            },
-            onFabMultiChoiceClick = {
-                isFabExpanded = false
-                showMultiChoiceDialog = true
-            },
-            modifier = Modifier.fillMaxSize()
-        )
+            }
+        },
+        onDownload = { videoId ->
+            VideoFileDownloadWorker.registerWorker(context, videoId)
+        },
+        onReimport = { videoId ->
+            videoToReimportId = videoId
+        },
+        onDeleteSingleVideo = { videoId ->
+            videoToDeleteId = videoId
+        },
+        onNavigateBack = onNavigateBack,
+        onDeleteVideos = {
+            scope.launch(Dispatchers.IO) {
+                // 選択された動画をプレイリストから削除
+                val currentPlaylist = playlistViewModel.getFromIdAsync(currentId).await()
+                currentPlaylist?.let { pl ->
+                    val result = playlistViewModel.removeVideosFromPlaylist(
+                        pl,
+                        selectedItems.toList()
+                    )
+                    if (result.isFailure) {
+                        withContext(Dispatchers.Main) {
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                    }
+                }
 
-        // Snackbar用のホスト
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter)
-        )
-    }
+                withContext(Dispatchers.Main) {
+                    selectedItems.clear()
+                }
+            }
+        },
+        onSortRuleChange = { rule ->
+            preferences.videoOrderRule = rule
+        },
+        onOrderUpToggle = {
+            preferences.videoOrderUp = !orderUp
+        },
+        onSyncRuleChange = { rule ->
+            scope.launch(Dispatchers.IO) {
+                val pl = playlistViewModel.getFromIdAsync(currentId).await()
+                val type = pl?.type as? Playlist.Type.CloudPlaylist
+                if (pl != null && type != null) {
+                    val updatedType = type.copy(syncRule = rule)
+                    val result = playlistViewModel.update(pl.copy(type = updatedType))
+                    if (result.isFailure) {
+                        withContext(Dispatchers.Main) {
+                            snackbarHostState.showSnackbar(msgOperationFailed)
+                        }
+                    }
+                }
+            }
+        },
+        onFabExpandToggle = {
+            isFabExpanded = !isFabExpanded
+        },
+        onFabMainClick = {
+            // Syncモード: 同期実行
+            val cloudType = playlist?.type as? Playlist.Type.CloudPlaylist
+            if (cloudType != null) {
+                // Worker登録を先に実行（snackbarは待機するため）
+                VideoInfoDownloadWorker.registerSyncWorker(
+                    context,
+                    currentId,
+                    cloudType.url
+                )
+                // スナックバーは非同期で表示
+                scope.launch {
+                    snackbarHostState.showSnackbar(msgSyncStarted)
+                }
+            }
+        },
+        onFabUrlClick = {
+            isFabExpanded = false
+            showUrlInputDialog = true
+        },
+        onFabMultiChoiceClick = {
+            isFabExpanded = false
+            showMultiChoiceDialog = true
+        },
+        modifier = modifier.fillMaxSize(),
+        snackbarHostState = snackbarHostState
+    )
 
     // 削除確認ダイアログ（プレイリストから外す or 動画を削除する）
     videoToDeleteId?.let { id ->
@@ -988,7 +1000,8 @@ private fun VideoListScreenPreview() {
             onFabExpandToggle = { },
             onFabMainClick = { },
             onFabUrlClick = { },
-            onFabMultiChoiceClick = { }
+            onFabMultiChoiceClick = { },
+            snackbarHostState = remember { SnackbarHostState() }
         )
     }
 }

--- a/app/src/main/kotlin/net/turtton/ytalarm/viewmodel/AlarmViewModel.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/viewmodel/AlarmViewModel.kt
@@ -1,11 +1,13 @@
 package net.turtton.ytalarm.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import arrow.core.Either
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
@@ -43,7 +45,13 @@ class AlarmViewModel(private val useCaseContainer: UseCaseContainer<*, *, *, *>)
      * suspend関数内からの呼び出しには[deleteSync]を使用すること。
      */
     fun delete(alarm: Alarm) = viewModelScope.launch {
-        deleteSync(alarm)
+        try {
+            deleteSync(alarm)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Log.e(TAG, "Failed to delete alarm: ${alarm.id}", e)
+        }
     }
 
     /**
@@ -72,6 +80,10 @@ class AlarmViewModel(private val useCaseContainer: UseCaseContainer<*, *, *, *>)
         useCaseContainer.createSnoozeAlarm(originalAlarm)
 
     suspend fun getEnabledAlarmsSync(): List<Alarm> = useCaseContainer.getEnabledAlarms()
+
+    companion object {
+        private const val TAG = "AlarmViewModel"
+    }
 }
 
 class AlarmViewModelFactory(private val useCaseContainer: UseCaseContainer<*, *, *, *>) :

--- a/app/src/main/kotlin/net/turtton/ytalarm/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/viewmodel/PlaylistViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -23,9 +24,11 @@ class PlaylistViewModel(private val useCaseContainer: UseCaseContainer<*, *, *, 
         viewModelScope.launch {
             // アプリ起動直後のI/O負荷を軽減するため少し遅延
             delay(THUMBNAIL_VALIDATION_DELAY_MS)
-            runCatching {
+            try {
                 useCaseContainer.validateAndUpdateThumbnails()
-            }.onFailure { e ->
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 Log.e(TAG, "Failed to validate thumbnails", e)
             }
         }
@@ -46,29 +49,60 @@ class PlaylistViewModel(private val useCaseContainer: UseCaseContainer<*, *, *, 
         useCaseContainer.getPlaylistsByIdsSync(ids)
     }
 
-    fun update(playlist: Playlist) = viewModelScope.launch {
+    suspend fun update(playlist: Playlist): Result<Unit> = try {
         useCaseContainer.updatePlaylist(playlist)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to update playlist: ${playlist.id}", e)
+        Result.failure(e)
     }
 
-    fun update(playlists: List<Playlist>) = viewModelScope.launch {
+    suspend fun update(playlists: List<Playlist>): Result<Unit> = try {
         useCaseContainer.updateAllPlaylists(playlists)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to update playlists", e)
+        Result.failure(e)
     }
 
     fun insertAsync(playlist: Playlist): Deferred<Long> = viewModelScope.async {
         useCaseContainer.insertPlaylist(playlist)
     }
 
-    fun delete(playlist: Playlist) = viewModelScope.launch {
+    suspend fun delete(playlist: Playlist): Result<Unit> = try {
         useCaseContainer.deletePlaylist(playlist)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to delete playlist: ${playlist.id}", e)
+        Result.failure(e)
     }
 
-    fun delete(playlists: List<Playlist>) = viewModelScope.launch {
+    suspend fun delete(playlists: List<Playlist>): Result<Unit> = try {
         useCaseContainer.deleteAllPlaylists(playlists)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to delete playlists", e)
+        Result.failure(e)
     }
 
-    fun removeVideosFromPlaylist(playlist: Playlist, videoIds: List<Long>) = viewModelScope.launch {
-        useCaseContainer.removeVideosFromPlaylist(playlist, videoIds)
-    }
+    suspend fun removeVideosFromPlaylist(playlist: Playlist, videoIds: List<Long>): Result<Unit> =
+        try {
+            useCaseContainer.removeVideosFromPlaylist(playlist, videoIds)
+            Result.success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Log.e(TAG, "Failed to remove videos from playlist: ${playlist.id}", e)
+            Result.failure(e)
+        }
 
     companion object {
         private const val TAG = "PlaylistViewModel"

--- a/app/src/main/kotlin/net/turtton/ytalarm/viewmodel/VideoViewModel.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/viewmodel/VideoViewModel.kt
@@ -1,13 +1,14 @@
 package net.turtton.ytalarm.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 import net.turtton.ytalarm.kernel.entity.Video
 import net.turtton.ytalarm.usecase.UseCaseContainer
 import net.turtton.ytalarm.usecase.ReimportResult as UseCaseReimportResult
@@ -47,24 +48,48 @@ class VideoViewModel(private val useCaseContainer: UseCaseContainer<*, *, *, *>)
         useCaseContainer.getVideosExceptVideoIdsSync(ids)
     }
 
-    fun update(video: Video) = viewModelScope.launch {
+    suspend fun update(video: Video): Result<Unit> = try {
         useCaseContainer.updateVideo(video)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to update video: ${video.id}", e)
+        Result.failure(e)
     }
 
     fun insertAsync(video: Video): Deferred<Long> = viewModelScope.async {
         useCaseContainer.insertVideo(video)
     }
 
-    fun insert(videos: List<Video>) = viewModelScope.launch {
+    suspend fun insert(videos: List<Video>): Result<Unit> = try {
         useCaseContainer.insertAllVideos(videos)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to insert videos", e)
+        Result.failure(e)
     }
 
-    fun delete(video: Video) = viewModelScope.launch {
+    suspend fun delete(video: Video): Result<Unit> = try {
         useCaseContainer.deleteVideo(video)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to delete video: ${video.id}", e)
+        Result.failure(e)
     }
 
-    fun delete(videos: List<Video>) = viewModelScope.launch {
+    suspend fun delete(videos: List<Video>): Result<Unit> = try {
         useCaseContainer.deleteAllVideos(videos)
+        Result.success(Unit)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(TAG, "Failed to delete videos", e)
+        Result.failure(e)
     }
 
     /**
@@ -84,6 +109,10 @@ class VideoViewModel(private val useCaseContainer: UseCaseContainer<*, *, *, *>)
 
             is UseCaseReimportResult.Error.Parse -> ReimportResult.Error.Parse
         }
+
+    companion object {
+        private const val TAG = "VideoViewModel"
+    }
 }
 
 class VideoViewModelFactory(private val useCaseContainer: UseCaseContainer<*, *, *, *>) :

--- a/app/src/main/kotlin/net/turtton/ytalarm/worker/VideoInfoDownloadWorker.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/worker/VideoInfoDownloadWorker.kt
@@ -112,26 +112,39 @@ class VideoInfoDownloadWorker(appContext: Context, workerParams: WorkerParameter
         targetUrl: String,
         playlistArray: LongArray?
     ): Result {
-        val playlistResult = useCaseContainer.importCloudPlaylist(targetUrl)
+        val importingPlaylistId = findImportingPlaylistId(useCaseContainer, playlistArray)
+        val playlistResult = useCaseContainer.importCloudPlaylist(targetUrl, importingPlaylistId)
         return playlistResult.fold(
             ifLeft = { failure ->
                 Log.e(WORKER_ID, "Import failed. Url: $targetUrl, reason: $failure")
                 Result.failure()
             },
             ifRight = { newPlaylistId ->
-                if (playlistArray != null && playlistArray.isNotEmpty()) {
+                val otherPlaylists = playlistArray
+                    ?.filter { it != importingPlaylistId }
+                    ?.toLongArray()
+                if (otherPlaylists != null && otherPlaylists.isNotEmpty()) {
                     val newPlaylist = useCaseContainer.getPlaylistByIdSync(newPlaylistId)
                     if (newPlaylist != null) {
                         addCloudPlaylistVideosToPlaylists(
                             useCaseContainer,
                             newPlaylist.videos,
-                            playlistArray
+                            otherPlaylists
                         )
                     }
                 }
                 Result.success()
             }
         )
+    }
+
+    private suspend fun findImportingPlaylistId(
+        useCaseContainer: UseCaseContainer<*, *, *, *>,
+        playlistArray: LongArray?
+    ): Long? {
+        if (playlistArray == null || playlistArray.isEmpty()) return null
+        val playlists = useCaseContainer.getPlaylistsByIdsSync(playlistArray.toList())
+        return playlists.firstOrNull { it.type is Playlist.Type.Importing }?.id
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo = createForegroundInfo()

--- a/app/src/main/kotlin/net/turtton/ytalarm/worker/VideoInfoDownloadWorker.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/worker/VideoInfoDownloadWorker.kt
@@ -220,13 +220,23 @@ class VideoInfoDownloadWorker(appContext: Context, workerParams: WorkerParameter
         playlistArray: LongArray
     ) {
         val playlists = useCaseContainer.getPlaylistsByIdsSync(playlistArray.toList())
-        val updatedPlaylists = playlists.mapNotNull { playlist ->
-            if (playlist.type !is Playlist.Type.Importing) return@mapNotNull null
+        val toUpdate = mutableListOf<Playlist>()
+        val toDelete = mutableListOf<Playlist>()
+
+        playlists.forEach { playlist ->
+            if (playlist.type !is Playlist.Type.Importing) return@forEach
 
             // プレイリスト内の全動画が更新中でないかチェック
             val videos = useCaseContainer.getVideosByIdsSync(playlist.videos)
             val hasUpdating = videos.any { it.state.isUpdating() }
-            if (hasUpdating) return@mapNotNull null
+            if (hasUpdating) return@forEach
+
+            val allFailed = videos.isEmpty() || videos.all { it.state is Video.State.Failed }
+            if (allFailed) {
+                Log.d(WORKER_ID, "Cleaning up failed importing playlist: ${playlist.id}")
+                toDelete.add(playlist)
+                return@forEach
+            }
 
             var updated = playlist.copy(type = Playlist.Type.Original)
             // サムネイルがNoneの場合、最初のInformation動画のサムネイルに更新
@@ -236,10 +246,14 @@ class VideoInfoDownloadWorker(appContext: Context, workerParams: WorkerParameter
                     updated = updated.copy(thumbnail = Playlist.Thumbnail.Video(firstReady.id))
                 }
             }
-            updated
+            toUpdate.add(updated)
         }
-        if (updatedPlaylists.isNotEmpty()) {
-            useCaseContainer.updateAllPlaylists(updatedPlaylists)
+
+        if (toUpdate.isNotEmpty()) {
+            useCaseContainer.updateAllPlaylists(toUpdate)
+        }
+        if (toDelete.isNotEmpty()) {
+            useCaseContainer.deleteAllPlaylists(toDelete)
         }
     }
 

--- a/usecase/src/main/kotlin/net/turtton/ytalarm/usecase/ImportUseCase.kt
+++ b/usecase/src/main/kotlin/net/turtton/ytalarm/usecase/ImportUseCase.kt
@@ -144,18 +144,29 @@ interface ImportUseCase<LExec, RExec, LDS, RDS>
     }
 
     /**
-     * クラウドプレイリストをインポートする。
-     * 重複チェックを行い、新規動画をDBに登録してプレイリストを作成する。
+     * URLからクラウドプレイリストをインポートする。
+     * プレイリストURLと単一動画URLの両方に対応し、重複チェックを行い、
+     * 新規動画をDBに登録してCloudPlaylistを作成する。
      *
-     * @param url プレイリストURL
+     * - プレイリストURL: プレイリスト名をタイトルに使用し、全エントリを動画として登録
+     * - 単一動画URL: 動画タイトルをプレイリスト名として1件のCloudPlaylistを作成
+     *
+     * [existingPlaylistId] が指定された場合、新規プレイリストを作成せず
+     * 既存プレイリスト（通常は[Playlist.Type.Importing]）をCloudPlaylistに変換して動画を設定する。
+     *
+     * @param url プレイリストURLまたは動画URL
+     * @param existingPlaylistId 再利用する既存プレイリストのID（nullの場合は新規作成）
      * @return インポート結果（プレイリストID or エラー）
      */
-    suspend fun importCloudPlaylist(url: String): Either<ImportResult.Failure, Long> {
+    suspend fun importCloudPlaylist(
+        url: String,
+        existingPlaylistId: Long? = null
+    ): Either<ImportResult.Failure, Long> {
         val lExecutor = localDataSource.dataSource.createExecutor()
         val rExecutor = remoteDataSource.dataSource.createExecutor()
 
         return when (
-            val result = remoteDataSource.videoInfoRepository.fetchPlaylistInfo(rExecutor, url)
+            val result = remoteDataSource.videoInfoRepository.fetchVideoInfo(rExecutor, url)
         ) {
             is Either.Left -> Either.Left(
                 when (result.value) {
@@ -167,18 +178,64 @@ interface ImportUseCase<LExec, RExec, LDS, RDS>
             )
 
             is Either.Right -> {
-                val videoInfoList = result.value
-                val videoIds = importVideoInfoList(lExecutor, videoInfoList)
+                val info = result.value
+                val typeData = info.typeData
+                val (playlistTitle, videoInfoList) = when (typeData) {
+                    is VideoInformation.Type.Playlist ->
+                        (info.title?.takeIf { it.isNotBlank() } ?: "Playlist") to
+                            typeData.entries
 
-                val playlist = Playlist(
-                    title = videoInfoList.firstOrNull()?.title ?: "Playlist",
-                    videos = videoIds,
-                    type = Playlist.Type.CloudPlaylist(url, Playlist.SyncRule.ALWAYS_ADD)
+                    is VideoInformation.Type.Video ->
+                        (
+                            info.title?.takeIf { it.isNotBlank() }
+                                ?: typeData.fullTitle
+                            ) to listOf(info)
+                }
+                val videoIds = importVideoInfoList(lExecutor, videoInfoList)
+                val type = Playlist.Type.CloudPlaylist(url, Playlist.SyncRule.ALWAYS_ADD)
+                Either.Right(
+                    upsertCloudPlaylist(
+                        lExecutor,
+                        existingPlaylistId,
+                        playlistTitle,
+                        videoIds,
+                        type
+                    )
                 )
-                val playlistId = localDataSource.playlistRepository.insert(lExecutor, playlist)
-                Either.Right(playlistId)
             }
         }
+    }
+
+    private suspend fun upsertCloudPlaylist(
+        executor: LExec,
+        existingPlaylistId: Long?,
+        title: String,
+        videoIds: List<Long>,
+        type: Playlist.Type.CloudPlaylist
+    ): Long {
+        if (existingPlaylistId != null) {
+            val existing = localDataSource.playlistRepository.getFromIdSync(
+                executor,
+                existingPlaylistId
+            )
+            if (existing != null) {
+                val thumbnail = videoIds.firstOrNull()
+                    ?.let { Playlist.Thumbnail.Video(it) }
+                    ?: Playlist.Thumbnail.None
+                localDataSource.playlistRepository.update(
+                    executor,
+                    existing.copy(
+                        title = title,
+                        videos = videoIds,
+                        type = type,
+                        thumbnail = thumbnail
+                    )
+                )
+                return existingPlaylistId
+            }
+        }
+        val playlist = Playlist(title = title, videos = videoIds, type = type)
+        return localDataSource.playlistRepository.insert(executor, playlist)
     }
 
     /**

--- a/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/ImportUseCaseTest.kt
+++ b/usecase/src/test/kotlin/net/turtton/ytalarm/usecase/ImportUseCaseTest.kt
@@ -142,6 +142,191 @@ class ImportUseCaseTest :
             }
         }
 
+        context("importCloudPlaylist") {
+            test("playlist URL: uses playlist title, not first video title") {
+                val playlistUrl = "http://example.com/playlist"
+                val entry1 = VideoInformation(
+                    id = "vid1",
+                    title = "First Song Title",
+                    url = "http://example.com/vid1",
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Video("First Song Title", "", "")
+                )
+                val entry2 = VideoInformation(
+                    id = "vid2",
+                    title = "Second Song Title",
+                    url = "http://example.com/vid2",
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Video("Second Song Title", "", "")
+                )
+                val playlistInfo = VideoInformation(
+                    id = "playlist1",
+                    title = "My Awesome Playlist",
+                    url = playlistUrl,
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Playlist(listOf(entry1, entry2))
+                )
+                fakeVideoInfoRepo.videoInfoResponses[playlistUrl] = Either.Right(playlistInfo)
+
+                val result = useCase.importCloudPlaylist(playlistUrl)
+
+                result.isRight() shouldBe true
+                val playlistId = result.getOrNull()!!
+                val createdPlaylist =
+                    fakePlaylistRepo.currentData.find { it.id == playlistId }
+                createdPlaylist?.title shouldBe "My Awesome Playlist"
+                fakeVideoRepo.currentData.size shouldBe 2
+            }
+
+            test("playlist URL with null title: falls back to default") {
+                val playlistUrl = "http://example.com/playlist"
+                val entry = VideoInformation(
+                    id = "vid1",
+                    title = "Song Title",
+                    url = "http://example.com/vid1",
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Video("Song Title", "", "")
+                )
+                val playlistInfo = VideoInformation(
+                    id = "playlist1",
+                    title = null,
+                    url = playlistUrl,
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Playlist(listOf(entry))
+                )
+                fakeVideoInfoRepo.videoInfoResponses[playlistUrl] = Either.Right(playlistInfo)
+
+                val result = useCase.importCloudPlaylist(playlistUrl)
+
+                result.isRight() shouldBe true
+                val playlistId = result.getOrNull()!!
+                val createdPlaylist =
+                    fakePlaylistRepo.currentData.find { it.id == playlistId }
+                createdPlaylist?.title shouldBe "Playlist"
+            }
+
+            test("single video URL: uses video title as playlist name") {
+                val videoUrl = "http://example.com/video"
+                val videoInfo = VideoInformation(
+                    id = "vid1",
+                    title = "Single Video Title",
+                    url = videoUrl,
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Video(
+                        "Single Video Title",
+                        "http://thumb.com",
+                        "http://example.com/video.mp4"
+                    )
+                )
+                fakeVideoInfoRepo.videoInfoResponses[videoUrl] = Either.Right(videoInfo)
+
+                val result = useCase.importCloudPlaylist(videoUrl)
+
+                result.isRight() shouldBe true
+                val playlistId = result.getOrNull()!!
+                val createdPlaylist =
+                    fakePlaylistRepo.currentData.find { it.id == playlistId }
+                createdPlaylist?.title shouldBe "Single Video Title"
+                createdPlaylist?.videos?.size shouldBe 1
+            }
+
+            test("network error: returns failure") {
+                fakeVideoInfoRepo.videoInfoResponses["http://example.com/playlist"] =
+                    Either.Left(VideoInfoError.NetworkError(RuntimeException("network")))
+
+                val result =
+                    useCase.importCloudPlaylist("http://example.com/playlist")
+
+                result.isLeft() shouldBe true
+                result.leftOrNull() shouldBe ImportResult.Failure.Network
+            }
+
+            test("playlist URL with blank title: falls back to default") {
+                val playlistUrl = "http://example.com/playlist"
+                val entry = VideoInformation(
+                    id = "vid1",
+                    title = "Song Title",
+                    url = "http://example.com/vid1",
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Video("Song Title", "", "")
+                )
+                val playlistInfo = VideoInformation(
+                    id = "playlist1",
+                    title = "   ",
+                    url = playlistUrl,
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Playlist(listOf(entry))
+                )
+                fakeVideoInfoRepo.videoInfoResponses[playlistUrl] = Either.Right(playlistInfo)
+
+                val result = useCase.importCloudPlaylist(playlistUrl)
+
+                result.isRight() shouldBe true
+                val playlistId = result.getOrNull()!!
+                val createdPlaylist =
+                    fakePlaylistRepo.currentData.find { it.id == playlistId }
+                createdPlaylist?.title shouldBe "Playlist"
+            }
+
+            test("single video URL with blank title: falls back to fullTitle") {
+                val videoUrl = "http://example.com/video"
+                val videoInfo = VideoInformation(
+                    id = "vid1",
+                    title = "",
+                    url = videoUrl,
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Video(
+                        "Full Title From TypeData",
+                        "http://thumb.com",
+                        "http://example.com/video.mp4"
+                    )
+                )
+                fakeVideoInfoRepo.videoInfoResponses[videoUrl] = Either.Right(videoInfo)
+
+                val result = useCase.importCloudPlaylist(videoUrl)
+
+                result.isRight() shouldBe true
+                val playlistId = result.getOrNull()!!
+                val createdPlaylist =
+                    fakePlaylistRepo.currentData.find { it.id == playlistId }
+                createdPlaylist?.title shouldBe "Full Title From TypeData"
+            }
+
+            test("existingPlaylistId: reuses existing playlist") {
+                val existingPlaylist = Playlist(
+                    id = 10L,
+                    title = "Old Title",
+                    type = Playlist.Type.Importing
+                )
+                fakePlaylistRepo.resetWith(existingPlaylist)
+
+                val playlistUrl = "http://example.com/playlist"
+                val entry = VideoInformation(
+                    id = "vid1",
+                    title = "Song",
+                    url = "http://example.com/vid1",
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Video("Song", "", "")
+                )
+                val playlistInfo = VideoInformation(
+                    id = "playlist1",
+                    title = "Correct Playlist Name",
+                    url = playlistUrl,
+                    domain = "example.com",
+                    typeData = VideoInformation.Type.Playlist(listOf(entry))
+                )
+                fakeVideoInfoRepo.videoInfoResponses[playlistUrl] = Either.Right(playlistInfo)
+
+                val result = useCase.importCloudPlaylist(playlistUrl, existingPlaylistId = 10L)
+
+                result.isRight() shouldBe true
+                result.getOrNull() shouldBe 10L
+                val updatedPlaylist = fakePlaylistRepo.currentData.find { it.id == 10L }
+                updatedPlaylist?.title shouldBe "Correct Playlist Name"
+                fakePlaylistRepo.currentData.size shouldBe 1
+            }
+        }
+
         context("syncCloudPlaylist") {
             test("ALWAYS_ADD: adds new videos to existing") {
                 val playlist = Playlist(


### PR DESCRIPTION
# Type

- Bug fix(バグ修正)
- Improvement(機能/コード改善)

# Description

## Bug Fixes

### Playlist title not correctly extracted
When importing a cloud playlist (e.g. SoundCloud), the first video's title was used as the playlist name instead of the actual playlist title. Root cause: `fetchPlaylistInfo()` discarded the top-level `VideoInformation.title` containing the real playlist name.

**Fix**: Changed `importCloudPlaylist()` to use `fetchVideoInfo()` and extract the playlist title from the top-level `info.title`. Added `isNullOrBlank()` fallback — for `Video` type, falls back to `fullTitle`.

### Duplicate playlist creation on import
Importing a playlist URL created both an "Importing" placeholder playlist and a separate "CloudPlaylist", resulting in duplicates.

**Fix**: Added `existingPlaylistId` parameter to `importCloudPlaylist()`. `VideoInfoDownloadWorker` now finds the existing "Importing" playlist ID and passes it, so the import reuses the placeholder instead of creating a new entry. Extracted `upsertCloudPlaylist()` helper for clarity.

### Stale thumbnail reference
`upsertCloudPlaylist()` retained `existing.thumbnail` when `videoIds` was empty, leaving a broken reference.

**Fix**: Changed to use `Playlist.Thumbnail.None` when no videos are present.

## UI Improvements

### Screen-local state not resetting on playlist change
When navigating between different playlists in `VideoListScreen`, local state (selected items, FAB expansion, dialogs, etc.) was not reset.

**Fix**: Extracted `VideoListScreenInner` composable wrapped in `key(playlistId)` to force full recomposition on playlist ID change.

### SnackbarHostState propagation
`VideoListScreenContent` had an internal dead `SnackbarHostState` separate from the parent's, causing snackbar messages to not display correctly.

**Fix**: Made `snackbarHostState` a required parameter (no default). Parent passes its instance directly. Removed duplicate `SnackbarHost` overlay from `AllVideosScreen`.

### Sync rotation animation guard
The sync rotation `LaunchedEffect` ran even when not in sync mode.

**Fix**: Wrapped in `if (isSyncMode)` guard.

## Tests

Added 7 new test cases for `importCloudPlaylist`:
- Playlist title extraction from top-level info
- Null title fallback to "Playlist"
- Blank title fallback to "Playlist" / fullTitle
- Single video URL handling
- Network error propagation
- Existing playlist ID reuse (no duplicate creation)

# Related Issues

N/A

# Before finish

- [x] I read the [Contributing guide](https://github.com/turtton/YtAlarm/blob/HEAD/.github/CONTRIBUTING.md).
- [x] Run Gradle tasks `formatKotlin` and `check` and make sure no error message is displayed.
- [x] Removed unnecessary commented out code and debug print code.