### PR TITLE
fix(ui): make sort buttons trigger recomposition on all list screens (#318)

### DIFF
--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AlarmListScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AlarmListScreen.kt
@@ -337,8 +337,8 @@ fun AlarmListScreen(
 
     val activity = context.findActivity() ?: return
     val preferences = activity.privatePreferences
-    val orderRule = preferences.alarmOrderRule
-    val orderUp = preferences.alarmOrderUp
+    var orderRule by remember { mutableStateOf(preferences.alarmOrderRule) }
+    var orderUp by remember { mutableStateOf(preferences.alarmOrderUp) }
 
     // スヌーズアラームを除外してソート
     val sortedAlarms = remember(allAlarms, orderRule, orderUp) {
@@ -440,9 +440,12 @@ fun AlarmListScreen(
         onOpenDrawer = onOpenDrawer,
         onSortRuleChange = { rule ->
             preferences.alarmOrderRule = rule
+            orderRule = rule
         },
         onOrderUpToggle = {
-            preferences.alarmOrderUp = !orderUp
+            val newOrderUp = !orderUp
+            preferences.alarmOrderUp = newOrderUp
+            orderUp = newOrderUp
         },
         onCreateAlarm = {
             editState = AlarmEditState.CreatingNew(createDefaultAlarm())

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AllVideosScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AllVideosScreen.kt
@@ -78,8 +78,8 @@ fun AllVideosScreen(
 
     val activity = context.findActivity() ?: return
     val preferences = activity.privatePreferences
-    val orderRule = preferences.videoOrderRule
-    val orderUp = preferences.videoOrderUp
+    var orderRule by remember { mutableStateOf(preferences.videoOrderRule) }
+    var orderUp by remember { mutableStateOf(preferences.videoOrderUp) }
 
     // 全動画を取得
     val videos by videoViewModel.allVideos.observeAsState(emptyList())
@@ -141,9 +141,12 @@ fun AllVideosScreen(
             onDeleteVideos = { /* Not applicable for all videos mode */ },
             onSortRuleChange = { rule ->
                 preferences.videoOrderRule = rule
+                orderRule = rule
             },
             onOrderUpToggle = {
-                preferences.videoOrderUp = !orderUp
+                val newOrderUp = !orderUp
+                preferences.videoOrderUp = newOrderUp
+                orderUp = newOrderUp
             },
             onSyncRuleChange = { /* Not applicable for all videos mode */ },
             onFabExpandToggle = { /* Not used in all videos mode */ },

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/PlaylistScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/PlaylistScreen.kt
@@ -348,8 +348,8 @@ fun PlaylistScreen(
 
     val activity = context.findActivity() ?: return
     val preferences = activity.privatePreferences
-    val orderRule = preferences.playlistOrderRule
-    val orderUp = preferences.playlistOrderUp
+    var orderRule by remember { mutableStateOf(preferences.playlistOrderRule) }
+    var orderUp by remember { mutableStateOf(preferences.playlistOrderUp) }
 
     // ソート処理
     val sortedPlaylists = remember(playlists, orderRule, orderUp) {
@@ -473,9 +473,12 @@ fun PlaylistScreen(
         },
         onSortRuleChange = { rule ->
             preferences.playlistOrderRule = rule
+            orderRule = rule
         },
         onOrderUpToggle = {
-            preferences.playlistOrderUp = !orderUp
+            val newOrderUp = !orderUp
+            preferences.playlistOrderUp = newOrderUp
+            orderUp = newOrderUp
         },
         onCreatePlaylist = {
             onNavigateToVideoList(0L)

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
@@ -593,8 +593,8 @@ private fun VideoListScreenInner(
 
     val activity = context.findActivity() ?: return
     val preferences = activity.privatePreferences
-    val orderRule = preferences.videoOrderRule
-    val orderUp = preferences.videoOrderUp
+    var orderRule by remember { mutableStateOf(preferences.videoOrderRule) }
+    var orderUp by remember { mutableStateOf(preferences.videoOrderUp) }
 
     val playlistType = playlist?.type
     val isSyncMode = playlistType is Playlist.Type.CloudPlaylist
@@ -704,9 +704,12 @@ private fun VideoListScreenInner(
         },
         onSortRuleChange = { rule ->
             preferences.videoOrderRule = rule
+            orderRule = rule
         },
         onOrderUpToggle = {
-            preferences.videoOrderUp = !orderUp
+            val newOrderUp = !orderUp
+            preferences.videoOrderUp = newOrderUp
+            orderUp = newOrderUp
         },
         onSyncRuleChange = { rule ->
             scope.launch(Dispatchers.IO) {


### PR DESCRIPTION
## Type

- Bug fix(バグ修正)

## Description

SharedPreferences のソート設定変更が Compose の recomposition をトリガーしていなかったため、ソートボタン（🔽/🔼 およびソートルール選択）をクリックしても UI が更新されませんでした。

`orderRule` / `orderUp` を `val` から `var ... by remember { mutableStateOf(...) }` に変更し、コールバック内で SharedPreferences と State の両方を更新することで、ソート変更時に正しく recomposition が実行されるよう修正しました。

### 変更ファイル
- `AlarmListScreen.kt`
- `AllVideosScreen.kt`
- `PlaylistScreen.kt`
- `VideoListScreen.kt`

## Related Issues

- resolve #318

## Before finish

- [x] I read the [Contributing guide](https://github.com/turtton/YtAlarm/blob/HEAD/.github/CONTRIBUTING.md).
- [x] Run Gradle tasks `formatKotlin` and `check` and make sure no error message is displayed.
- [x] Removed unnecessary commented out code and debug print code.