### PR TITLE
fix(ui): make sort dialog rows clickable with consistent spacing

### DIFF
--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AlarmListScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/AlarmListScreen.kt
@@ -2,10 +2,12 @@ package net.turtton.ytalarm.ui.compose.screens
 
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -208,6 +210,13 @@ fun AlarmListScreenContent(
                 Column {
                     sortOptions.forEachIndexed { index, option ->
                         Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onSortRuleChange(AlarmOrder.entries[index])
+                                    showSortDialog = false
+                                }
+                                .padding(vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             RadioButton(

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/PlaylistScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/PlaylistScreen.kt
@@ -1,10 +1,12 @@
 package net.turtton.ytalarm.ui.compose.screens
 
 import android.util.Log
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -234,6 +236,13 @@ fun PlaylistScreenContent(
                 Column {
                     sortOptions.forEachIndexed { index, option ->
                         Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onSortRuleChange(PlaylistOrder.entries[index])
+                                    showSortDialog = false
+                                }
+                                .padding(vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             RadioButton(

--- a/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
+++ b/app/src/main/kotlin/net/turtton/ytalarm/ui/compose/screens/VideoListScreen.kt
@@ -6,10 +6,12 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -401,6 +403,13 @@ fun VideoListScreenContent(
                 Column {
                     sortOptions.forEachIndexed { index, option ->
                         Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onSortRuleChange(VideoOrder.entries[index])
+                                    showSortDialog = false
+                                }
+                                .padding(vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             RadioButton(
@@ -461,6 +470,13 @@ fun VideoListScreenContent(
                 Column {
                     syncRuleOptions.forEachIndexed { index, option ->
                         Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onSyncRuleChange(Playlist.SyncRule.entries[index])
+                                    showSyncRuleDialog = false
+                                }
+                                .padding(vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             RadioButton(


### PR DESCRIPTION
# Type

- Bug fix(バグ修正)
- ~~New feature(新機能)~~
- ~~Improvement(機能/コード改善)~~
- ~~Document changes(翻訳などのドキュメント関係の変更)~~
- ~~Other(その他)~~

# Description

ソートルール選択ダイアログおよびSyncRule選択ダイアログの各行に Modifier.fillMaxWidth().clickable() を追加し、ラジオボタン以外のテキスト領域をタップしても選択できるようにしました。

項目間の余白を 8.dp から 4.dp に縮小し、他のダイアログと統一しました。

# Related Issues

なし

# Before finish

- [x] I read the Contributing guide.
- [x] Run Gradle tasks formatKotlin and check and make sure no error message is displayed.
- [x] Removed unnecessary commented out code and debug print code.